### PR TITLE
Removed comma causing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fl-events",
   "private": true,
   "scripts": {
-    "start": "meteor run",    
+    "start": "meteor run"    
   },
   "dependencies": {
     "meteor-node-stubs": "~0.2.0"


### PR DESCRIPTION
@AndyatFocallocal There was an accidental comma in package.json. That was causing an error in the building process. It should work now.