### PR TITLE
Minor spelling errors

### DIFF
--- a/both/i18n/en/app.en.i18n.json
+++ b/both/i18n/en/app.en.i18n.json
@@ -257,9 +257,9 @@
     "text": {
       "0": {
         "0": "Welcome to the Gatherings Maps.",
-        "1": "This is a tool to spread possitivity around the world by connecting people, communities and ideas. Click on the buttons bellow to explore what you can do here.",
+        "1": "This is a tool to spread positivity around the world by connecting people, communities and ideas. Click on the buttons below to explore what you can do here.",
         "2": "Legend",
-        "3": "Filter to find events available nearby to help spread possitivity and build a better tomorrow",
+        "3": "Filter to find events available nearby to help spread positivity and build a better tomorrow",
         "4": "Map",
         "5": {
             "0": "Double click on the map to zoom in.",


### PR DESCRIPTION
Just noticed a couple words spelled incorrectly - "positivity" and "below."  Apologies if this is too small an issue to warrant a pull request, but I figured I'd help any way I could!