### PR TITLE
fixed activites link

### DIFF
--- a/client/templates/layouts/headerMenu/_header.html
+++ b/client/templates/layouts/headerMenu/_header.html
@@ -64,10 +64,10 @@
             </li>
 
             <li>
-                <a href="http://activities.focallocal.org/">
-                  <i class="material-icons">directions walk</i>
+                <a href="http://activities.focallocal.org/" title="Activites" class="center-align">
+                  <i class="material-icons">directions</i>
                   <div>
-                    {{_ "sideNav.content.6"}}
+                    {{_ "leftLinks.content.6"}}
                   </div>
                 </a>
               </li>
@@ -96,7 +96,7 @@
                 </div>
               </a>
             </li>
-            
+
           </ul>
 
           <ul class="side-nav" id="side-nav-left">


### PR DESCRIPTION
This has caused the activites link to show "sideNav.content.6" instead of the value.

I also added relevant css and updated icon name to match material-icons