### PR TITLE
Comment system only Coral login, no oAuth yet

### DIFF
--- a/imports/client/ui/pages/Page/index.js
+++ b/imports/client/ui/pages/Page/index.js
@@ -148,10 +148,11 @@ class Page extends Component {
         <Helmet>
           {/* The embed web address will need updated depending on environment */}
           {/* Package.json port will need updated if you leave embed at 3000*/}
-          <script src="http://127.0.0.1:3000/static/embed.js" async onload="
-          Coral.Talk.render(document.getElementById('coral_talk_stream'), {
-            talk: 'http://127.0.0.1:3000/'
-          });
+          <div id="coral_talk_stream"></div>
+          <script src="http://104.238.186.173:3005/static/embed.js" async onload="
+            Coral.Talk.render(document.getElementById('coral_talk_stream'), {
+              talk: 'http://104.238.186.173:3005/'
+            });
           "></script>
         </Helmet>
       </div>

--- a/imports/client/ui/pages/Page/index.js
+++ b/imports/client/ui/pages/Page/index.js
@@ -10,6 +10,7 @@ import PageLoader from '/imports/client/ui/components/PageLoader'
 import EditPage from './Edit'
 import AttendingButton from './AttendingButton'
 import './style.scss'
+import {Helmet} from "react-helmet";
 
 class Page extends Component {
   constructor (props) {
@@ -143,6 +144,16 @@ class Page extends Component {
             src={mapUrl}
           />
         </Container>
+        <div id="coral_talk_stream"></div>
+        <Helmet>
+          {/* The embed web address will need updated depending on environment */}
+          {/* Package.json port will need updated if you leave embed at 3000*/}
+          <script src="http://127.0.0.1:3000/static/embed.js" async onload="
+          Coral.Talk.render(document.getElementById('coral_talk_stream'), {
+            talk: 'http://127.0.0.1:3000/'
+          });
+          "></script>
+        </Helmet>
       </div>
     )
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-day-picker": "^7.1.9",
     "react-dom": "^16.3.2",
     "react-google-maps": "^9.4.5",
+    "react-helmet": "^5.2.0",
     "react-hot-loader": "^4.1.3",
     "react-loadable": "^5.4.0",
     "react-places-autocomplete": "^7.1.1",


### PR DESCRIPTION
Functioning comment system without any third party oAuth, sign in is done through built in Coral Talk. In order to function you [must setup server](https://docs.coralproject.net/talk/) until we have system setup on host server. Pages function properly with or without the server operational, comments just don't show if not setup. If we don't pull into master, this branch can still be used by everyone to make adjustments.