### PR TITLE
Commenting updated to HTTPS, needs confirmed once live

### DIFF
--- a/imports/client/ui/pages/Page/index.js
+++ b/imports/client/ui/pages/Page/index.js
@@ -148,10 +148,9 @@ class Page extends Component {
         <Helmet>
           {/* The embed web address will need updated depending on environment */}
           {/* Package.json port will need updated if you leave embed at 3000*/}
-          <div id="coral_talk_stream"></div>
-          <script src="http://104.238.186.173:3005/static/embed.js" async onload="
+          <script src="https://talk.focallocal.org/static/embed.js" async onload="
             Coral.Talk.render(document.getElementById('coral_talk_stream'), {
-              talk: 'http://104.238.186.173:3005/'
+              talk: 'https://talk.focallocal.org/'
             });
           "></script>
         </Helmet>


### PR DESCRIPTION
Updated the script tag to reflect the url with https. Only way to confirm this is working is to give the URL time to update with new IP for talk.focallocal.org and then see if the live site actually shows the script.