### PR TITLE
saved unfinished New Event form to window obj before closing modal for later use in FormWizard

### DIFF
--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -59,9 +59,11 @@ class App extends Component {
       sessionStorage.setItem('redirect', '/?new=1')
       return <Redirect to='/sign-in' />
     }
+    /*
     else if(!isOpen){
       return <Redirect to='/home' />
     }
+    */
 
     return <NewEventLoadable isOpen={isOpen} location={location} history={history} />
   }

--- a/imports/client/ui/pages/NewEvent/FormWizard/index.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/index.js
@@ -55,12 +55,23 @@ class FormWizard extends Component {
   }
 
   loadModelFromStorage (empty) {
-    let initialObject = EventsSchema.clean({}, { mutate: true }) // get default values
-    initialObject.when = {
-      startingTime: getHour(),
-      endingTime: getHour(3),
-      recurring: { forever: true },
-      repeat: false
+    // on fields reset, get rid of any previously unfinished New Event
+    if(empty === true){
+      delete window.__unfinishedNewEvent
+    }
+
+    let initialObject;
+
+    if('__unfinishedNewEvent' in window){
+      initialObject = window.__unfinishedNewEvent
+    } else {
+      initialObject = EventsSchema.clean({}, { mutate: true }) // get default values
+      initialObject.when = {
+        startingTime: getHour(),
+        endingTime: getHour(3),
+        recurring: { forever: true },
+        repeat: false
+      }
     }
 
     return initialObject

--- a/imports/client/ui/pages/NewEvent/index.js
+++ b/imports/client/ui/pages/NewEvent/index.js
@@ -6,6 +6,7 @@ import { Modal, ModalHeader, ModalBody, ModalFooter, Button, Alert } from 'react
 import FormWizard from './FormWizard'
 import i18n from '/imports/both/i18n/en'
 import qs from 'query-string'
+import cloneDeep from 'clone-deep'
 import './styles.scss'
 
 const { NewEventModal: i18n_ } = i18n // Strings from i18n
@@ -44,6 +45,12 @@ class NewEventModal extends Component {
         this.setState({ googleLoaded: true })
       }
     }, 1000) // 1 second
+  }
+
+  componentDidUpdate(prevProps){
+    if(prevProps.location.pathname !== this.props.location.pathname){
+      delete window.__unfinishedNewEvent
+    }
   }
 
   componentWillUnmount () {
@@ -119,6 +126,9 @@ class NewEventModal extends Component {
 
         if (Meteor.isDevelopment) { console.log(err.details, err) }
       })
+
+      // get rid of any previously unfinished New Event
+      delete window.__unfinishedNewEvent
   }
 
   callNewEvent = model => {
@@ -156,6 +166,10 @@ class NewEventModal extends Component {
 
     const url = pathname + '?' + qs.stringify(queryStrings)
     this.props.history.push(url)
+
+    // toggleModal() closes modal, but it is not called after form submits  
+    // copy unfinished form to global window and check for it inside FormWizard 
+    window.__unfinishedNewEvent = cloneDeep(this.state.form.getModel())
   }
 
   toggleErrors = () => this.setState({ hasErrors: false })


### PR DESCRIPTION
This is my first ever pull request and more of a temporary patch.
Before modal closes, unfinished form is copied to a window obj for later retrieval. 
Unfinished form data is deleted after resetting or submitting a completed form, and between different route changes.
I also commented out a line that told the modal to redirect the user to /home every time it closed. It should now close back to where it was opened from.  
