### PR TITLE
Remove Attend button (both on EventInfo and Event Page)

### DIFF
--- a/imports/client/ui/pages/Map/EventsList/EventInfo/index.js
+++ b/imports/client/ui/pages/Map/EventsList/EventInfo/index.js
@@ -4,7 +4,7 @@ import { withTracker } from 'meteor/react-meteor-data'
 import PropTypes from 'prop-types'
 import { Button } from 'reactstrap'
 import i18n_ from '/imports/both/i18n/en/map.json'
-import AttendingButton from './../../../Page/AttendingButton'
+// import AttendingButton from './../../../Page/AttendingButton'  <-- currently disabled
 import HoursFormatted from '/imports/client/ui/components/HoursFormatted'
 import * as formatUtils from '/imports/client/utils/format'
 import './styles.scss'
@@ -64,7 +64,7 @@ class EventInfo extends Component {
       user
     } = this.props
 
-    const isLoggedIn = !!user 
+    const isLoggedIn = !!user
 
     if (!event) { return null }
 
@@ -94,11 +94,8 @@ class EventInfo extends Component {
           {/*
           <Button color='primary' onClick={this.getDirections}>Get Directions</Button>
           */}
-          <AttendingButton
-            _id={event._id}
-            history={history}
-            isLoggedIn={isLoggedIn}
-            user={user}/>
+          {/* attending button currently inactive until able to work with both maps:
+            <AttendingButton _id={event._id} history={history} isLoggedIn={isLoggedIn} user={user}/> */}
         </div>
 
         <hr className='divider' />

--- a/imports/client/ui/pages/Page/AttendingButton/index.js
+++ b/imports/client/ui/pages/Page/AttendingButton/index.js
@@ -1,3 +1,6 @@
+/*******************
+* CURRENTLY DISABLED - May be added back in future when works across both maps
+********************/
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Meteor } from 'meteor/meteor'

--- a/imports/client/ui/pages/Page/index.js
+++ b/imports/client/ui/pages/Page/index.js
@@ -8,7 +8,7 @@ import { scrollToElement } from '/imports/client/utils/DOMInteractions'
 import HoursFormatted from '/imports/client/ui/components/HoursFormatted'
 import PageLoader from '/imports/client/ui/components/PageLoader'
 import EditPage from './Edit'
-import AttendingButton from './AttendingButton'
+// import AttendingButton from './AttendingButton'  <-- currently disabled
 import './style.scss'
 import {Helmet} from "react-helmet";
 import qs from 'query-string'
@@ -121,9 +121,9 @@ class Page extends Component {
   }
 
   render() {
-    const { 
-      data, 
-      loaded 
+    const {
+      data,
+      loaded
     } = this.state
 
     if (!loaded) {
@@ -142,9 +142,9 @@ class Page extends Component {
       when
     } = data
 
-    const { 
-      history, 
-      user 
+    const {
+      history,
+      user
     } = this.props
 
     const categories = formatCategories(c)
@@ -192,12 +192,8 @@ class Page extends Component {
 
             <Col xs={4} className='right'>
               <SectionTitle title='Date and Time' />
-              <AttendingButton
-                _id={_id}
-                history={history}
-                isLoggedIn={isLoggedIn}
-                user={user}
-              />
+              {/* attending button currently inactive until able to work with both maps:
+                <AttendingButton _id={_id} history={history} isLoggedIn={isLoggedIn} user={user} />*/}
               <HoursFormatted data={when} />
 
               <Divider />


### PR DESCRIPTION
Removed the attend button from the UI (left 1 liner comment in case we need to add back in future). [relates to this issue on trello](https://trello.com/c/qfwPJzYU/488-both-delete-the-attend-button-not-in-the-page-only-in-the-preview)

Below are some screenshots of the revised look without the button.



![screenshot event page](https://user-images.githubusercontent.com/26905074/52808358-96c83e80-3085-11e9-9050-d9558bcd9e38.png)
![screenshot event map stub](https://user-images.githubusercontent.com/26905074/52808363-9a5bc580-3085-11e9-8c8b-fd9012bb8509.png)

