### PR TITLE
override AutoForm onChange method to handle dates

### DIFF
--- a/imports/client/utils/uniforms-custom/AutoForm.js
+++ b/imports/client/utils/uniforms-custom/AutoForm.js
@@ -4,6 +4,16 @@ import ValidatedQuickForm from './ValidatedQuickForm'
 
 const Auto = parent => class extends AutoForm.Auto(parent) {
     static Auto = Auto;
+    onChange (key, value) {
+      // starting date should not be later than ending date
+      if (key === 'when.endingDate' && value < this.getModel().when.startingDate) {
+        super.onChange('when.startingDate', value)
+      } else if (key === 'when.startingDate' && value > this.getModel().when.endingDate) {
+        super.onChange('when.endingDate', value)
+      }
+      // pass on all changes to super
+      super.onChange(key, value)
+    }
 }
 
 export default Auto(ValidatedQuickForm)


### PR DESCRIPTION
Fixes #771. This was not a current key task on Trello, sorry if that's an issue.

What I've done in this PR is check if `when.startingDate > when.endingDate` and if so adjusting the one that was not changed to match the new choice. 

Note that the starting and ending clock times can still be inconsistent if startingDate and endingDate are the same.