### PR TITLE
update schema+UI: default repeating weekday set to start date's weekday

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -264,6 +264,8 @@ const EventsSchema = new SimpleSchema({
       const type = this.siblingField('type')
       if (type.value !== 'week') {
         return null
+      } else if (!this.isSet) {
+        return [weekDays[this.field('when.startingDate').value.getDay()]]
       }
     }
   },

--- a/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
@@ -22,10 +22,12 @@ class Recurring extends Component {
       recurring
     } = model.when
 
+    const weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
     let forever = recurring.forever
     let monthly = recurring.monthly
-    let selectedDays = recurring.days || []
     let startingDate = model.when.startingDate || new Date()
+    let selectedDays = recurring.days || [weekDays[startingDate.getDay()]]
     let type = recurring.type
     let occurences = recurring.occurences
 


### PR DESCRIPTION
Relates to [issue #879](https://github.com/focallocal/fl-maps/issues/879)

**Solution:** add default value to the weekday field, which can be overwritten by the user filling out the form.
- update db schema autovalue: if recurring type is 'week', but weekday has not been set by the user, it will revert to the weekday of the event's start date.
- update react component: pass the autovalue to the weekday UI component so that the user sees the default weekday highlighted on the form itself, as per the screenshot below (start date 27th Feb => Wednesday). User can then replace the default/add further days to the default as needed.

Any questions let me know.

![screenshot from 2019-02-25 18-40-57](https://user-images.githubusercontent.com/26905074/53361844-9efb6600-3930-11e9-9741-7cdab2515773.png)


