### PR TITLE
Revert "update schema+UI: default repeating weekday set to start date's weekday"

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -264,8 +264,6 @@ const EventsSchema = new SimpleSchema({
       const type = this.siblingField('type')
       if (type.value !== 'week') {
         return null
-      } else if (!this.isSet) {
-        return [weekDays[this.field('when.startingDate').value.getDay()]]
       }
     }
   },

--- a/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
@@ -22,12 +22,10 @@ class Recurring extends Component {
       recurring
     } = model.when
 
-    const weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-
     let forever = recurring.forever
     let monthly = recurring.monthly
+    let selectedDays = recurring.days || []
     let startingDate = model.when.startingDate || new Date()
-    let selectedDays = recurring.days || [weekDays[startingDate.getDay()]]
     let type = recurring.type
     let occurences = recurring.occurences
 


### PR DESCRIPTION
Reverts focallocal/fl-maps#896

travis failed, although the PR was good. reverting so it can be made again, there is an intermittent bug in travis that seems to fail around 1 in 4 PR's