### PR TITLE
Events recurrence - complete timeDate module and repair recurrence selection

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -255,7 +255,8 @@ const EventsSchema = new SimpleSchema({
     type: Array,
     optional: true,
     custom: function () {
-      if (this.siblingField('type') === 'week') {
+      const type = this.siblingField('type')
+      if (type.value === 'week') {
         const atLeastOneDay = !this.value || !this.value.join('')
         return atLeastOneDay ? 'required' : undefined
       }
@@ -264,8 +265,6 @@ const EventsSchema = new SimpleSchema({
       const type = this.siblingField('type')
       if (type.value !== 'week') {
         return null
-      } else if (!this.isSet) {
-        return [weekDays[this.field('when.startingDate').value.getDay()]]
       }
     }
   },
@@ -296,16 +295,8 @@ const EventsSchema = new SimpleSchema({
   'when.recurring.monthly.value': {
     type: Number,
     autoValue: function () {
-      const type = this.siblingField('type')
-      let value = this.value
-      let dayInMonth = new Date().getDate()
-
-      if (type.value === 'byDayInMonth') {
-        value = (typeof value) === 'number' && value >= 0 ? value : dayInMonth
-        return value > 31 ? 31 : value < 1 ? 1 : value
-      } else {
-        value = (typeof value) === 'number' && value >= 0 ? value : Number(determinePosition(dayInMonth)[0])
-        return value > 4 ? 4 : value < 1 ? 1 : value
+      if (!this.value) {
+        return this.field('when.startingDate').value.getDate()
       }
     }
   },

--- a/imports/client/ui/components/HoursFormatted/index.js
+++ b/imports/client/ui/components/HoursFormatted/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { formatDateWithWords, formatDate } from '/imports/client/utils/format'
+import { findNextEvent, calibrateEndWeekday } from '/imports/client/utils/findNextEvent'
 import './styles.scss'
 
 const HoursFormatted = ({ data }) => {
@@ -10,9 +11,11 @@ const HoursFormatted = ({ data }) => {
     endingTime
   } = data
 
-  //------------------- Quick Fix see PR #875 ---------------------
+  //------------------- Quick Fixes see PR #875 ---------------------
   const startingDate = startDate === null ? new Date() : startDate
-  //---------------------------------------------------------------
+  //const isSameDay = startingDate.toDateString() === endingDate.toDateString()
+  const isSameDay = startingDate && endingDate ? startingDate.toDateString() === endingDate.toDateString() : true
+  //------------------------------------------------------------------------
 
   if (data.multipleDays) {
     const isEnding = !!endingDate
@@ -42,52 +45,115 @@ const HoursFormatted = ({ data }) => {
       every,
       forever,
       type,
-      repeat,
-      until
+      until,
+      occurences,
+      monthly,
+      recurrenceEndDate
     } = data.recurring
+    
+    const weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+    let daysOrdered = days
+    if (days) daysOrdered = weekDays.filter((e) => days.indexOf(e) >= 0)
 
-    // Reusable parts
-    const firstLine = `Every ${every} ${type + (every > 1 ? 's' : '')}`
-    const notForever = (
+    let nextEventInstance = findNextEvent(startingDate, type, every, days, monthly)
+
+    // DESCRIPTION: Reusable Fragment with timestamp on Next Occurence
+    const nextOccurence = (
+      <li className='hours-formatted regular-date'>
+        <span>Next:<br/>
+          {formatDateWithWords(nextEventInstance)}<br/>
+          {startingTime} - </span>
+        {isSameDay ? endingTime
+          : <div>
+            {formatDateWithWords(
+              new Date(Date.parse(nextEventInstance) + (endingDate.getTime() - startingDate.getTime()))
+            )}, {endingTime}
+          </div>
+        }
+      </li>
+    )
+
+    // DESCRIPTION: Reusable Fragment with repetition details
+    const repeatTitle = <span>Repeating:<br/></span>
+    const repeatSchedule = `every ${every > 1 ? every : ''} ${type + (every > 1 ? 's' : '')}`
+    const startingWeekday = startingDate.getDay()
+    let endingWeekday = endingDate.getDay()
+    if (daysOrdered) endingWeekday = weekDays.indexOf(daysOrdered[daysOrdered.length - 1])
+    const adjustedEndDate = calibrateEndWeekday(startingDate, endingDate, days, recurrenceEndDate)
+
+    const notForeverDay = (
       <div className='not-forever'>
-        <span>Available</span>
-        {repeat && ` for ${repeat} occurences`}
-        {(repeat && until) && ` or until ${formatDate(until)}`}
-        {(!repeat && until) && `until ${formatDate(until)}`}
+        {(data.repeat && occurences) && `until ${formatDateWithWords(recurrenceEndDate)}`}
+        {(data.repeat && until) && `until ${formatDateWithWords(until)}`}
+      </div>
+    )
+    const notForeverWeek = (
+      <div className='not-forever'>
+        {(data.repeat && occurences && startingWeekday === endingWeekday)
+          && `until ${formatDateWithWords(recurrenceEndDate)}`}
+        {(data.repeat && occurences && startingWeekday !== endingWeekday)
+          && `until ${formatDateWithWords(adjustedEndDate)}`}
+        {(data.repeat && until) && `until ${formatDateWithWords(until)}`}
+      </div>
+    )
+    const notForeverMonth = (
+      <div className='not-forever'>
+        {(data.repeat && occurences) && `through ${months[recurrenceEndDate.getMonth()]}`}
+        {(data.repeat && until) && `through ${months[until.getMonth()]}`}
       </div>
     )
 
     if (type === 'day') {
       return (
-        <div className='hours-formatted repeat'>
-          <span>{firstLine}, between {startingTime} - {endingTime} </span>
-          {!forever && notForever}
-        </div>
+        <ul className='hours-formatted repeat'>
+          {(forever == true) && nextOccurence}
+          {(!forever && recurrenceEndDate && new Date() < recurrenceEndDate) && nextOccurence}
+          <li>{repeatTitle} {repeatSchedule}, between {startingTime} - {endingTime} </li>
+          {!forever && notForeverDay}
+        </ul>
       )
     } else if (type === 'week') {
       return (
-        <div className='hours-formatted repeat'>
-          <div className='every-sentence'>{firstLine} on</div>
-          {days.map((day, index) => (
-            day &&
-              <div key={index} className='day'>
-                <div>{day.substr(0, 3)}</div>
-                <span>{startingTime} - {endingTime}</span>
-              </div>
-          ))}
-          {!forever && notForever}
-        </div>
+        <ul className='hours-formatted repeat'>
+          {(forever == true) && nextOccurence}
+          {(!forever && recurrenceEndDate && new Date() < recurrenceEndDate) && nextOccurence}
+          <li>
+            <span className='every-sentence'>{repeatTitle} {repeatSchedule}</span><br/>
+            {daysOrdered.map((day, index) => (
+              day &&
+                <div key={index} className='day'>
+                <span>on {day.substr(0, 3)}, {startingTime} - {endingTime}</span><br/>
+                </div>
+            ))}
+          </li>
+          {!forever && notForeverWeek}
+        </ul>
       )
-    } else {
-      // todo - handle "month"
+    } else if (type === 'month'){
+      return (
+        <ul className='hours-formatted repeat'>
+          {nextOccurence}
+          <li>
+            <span className='every-sentence'>{repeatTitle} {repeatSchedule} </span><br/>
+            <span>
+              {(monthly.type === 'byDayInMonth' && monthly.value === 1) && `on the ${monthly.value}st`}
+              {(monthly.type === 'byDayInMonth' && monthly.value === 2) && `on the ${monthly.value}nd`}
+              {(monthly.type === 'byDayInMonth' && monthly.value === 3) && `on the ${monthly.value}rd`}
+              {(monthly.type === 'byDayInMonth' && monthly.value > 3) && `on the ${monthly.value}th`}
+              {(monthly.type === 'byPosition' && monthly.value === 1) && `on the ${monthly.value}st ${weekDays[startingDate.getDay()]}`}
+              {(monthly.type === 'byPosition' && monthly.value === 2) && `on the ${monthly.value}nd ${weekDays[startingDate.getDay()]}`}
+              {(monthly.type === 'byPosition' && monthly.value === 3) && `on the ${monthly.value}rd ${weekDays[startingDate.getDay()]}`}
+              {(monthly.type === 'byPosition' && monthly.value > 3) && `on the ${monthly.value}th ${weekDays[startingDate.getDay()]}`}
+            </span>
+          </li>
+          {!forever && notForeverMonth}
+        </ul>
+      )
     }
   }
 
-  //------------------- Quick Fix see PR #875 ------------------------------
-  //const isSameDay = startingDate.toDateString() === endingDate.toDateString()
-  const isSameDay = startingDate && endingDate ? startingDate.toDateString() === endingDate.toDateString() : true
-  //------------------------------------------------------------------------
-
+  // DESCRIPTION: if !data.repeat then default view is start + end timestamp
   return (
     <div className='hours-formatted regular-date'>
       <span>{formatDateWithWords(startingDate)}, {startingTime} - </span>

--- a/imports/client/ui/components/HoursFormatted/styles.scss
+++ b/imports/client/ui/components/HoursFormatted/styles.scss
@@ -1,12 +1,14 @@
 
 .hours-formatted {
+  padding: 0;
+  list-style-position: inside;
 
   .day {
+    justify-content: left!important;
+    display: inline!important;
+  }
 
-    &>div:first-child {
-      display: inline-block;
-      width: 45px;
-      margin-right: 64px;
-    }
+  .every-sentence{
+    text-align: left;
   }
 }

--- a/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/Monthly/index.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/Monthly/index.js
@@ -55,7 +55,7 @@ class RecurrMonthly extends Component {
     if (value === 'byDayInMonth') {
       finalValue = dayInMonth
     } else {
-      finalValue = determinePosition(startingDate)[0] // get first letter which represents the position
+      finalValue = determinePosition(dayInMonth)[0] // get first letter which represents the position
     }
 
     form.change('when.recurring.monthly', { type: value, value: finalValue })

--- a/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
@@ -22,12 +22,10 @@ class Recurring extends Component {
       recurring
     } = model.when
 
-    const weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-
     let forever = recurring.forever
     let monthly = recurring.monthly
     let startingDate = model.when.startingDate || new Date()
-    let selectedDays = recurring.days || [weekDays[startingDate.getDay()]]
+    let selectedDays = recurring.days || []
     let type = recurring.type
     let occurences = recurring.occurences
 

--- a/imports/client/utils/findNextEvent.js
+++ b/imports/client/utils/findNextEvent.js
@@ -1,0 +1,107 @@
+// DESCRIPTION: This is the main function that iterates through event dates
+// in order to find the next one from the user's perspective
+export function findNextEvent (startingDate, type, every, days, monthly) {
+  const weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+  let daysOrdered = days
+  if (days) daysOrdered = weekDays.filter((e) => days.indexOf(e) >= 0)
+
+  let modifiedDate = new Date(startingDate)
+
+  // NOTE: Begin Loop
+  while (modifiedDate < new Date()) {
+    if (type === 'day') {
+      modifiedDate = new Date(modifiedDate.setDate(modifiedDate.getDate() + every))
+    } else if (type === 'week') {
+      let weekdayIndex = modifiedDate.getDay() // 0-6
+      let weekdayName = weekDays[weekdayIndex] // Sun-Sat
+
+      if (!daysOrdered.includes(weekdayName)) {
+        if (modifiedDate.getTime() === startingDate.getTime()) {
+          modifiedDate = resetEventWeekday(modifiedDate, daysOrdered, weekDays)
+        } else {
+          throw new Error('Event Iterator Malfunction')
+        }
+      } else if (daysOrdered.indexOf(weekdayName) < days.length - 1) {
+        modifiedDate = jumpToNextWeekdayInPeriod(modifiedDate, daysOrdered, weekDays)
+      } else if (daysOrdered.indexOf(weekdayName) === daysOrdered.length - 1) {
+        modifiedDate = jumpToNextWeek(modifiedDate, every, daysOrdered, weekDays)
+      } else {
+        throw new Error('Unknown weekly iteration error')
+      }
+    } else if (type === 'month') {
+      modifiedDate = jumpToNextMonth(modifiedDate, every, monthly.type, monthly.value, startingDate)
+    }
+  }
+  return modifiedDate
+}
+
+// DESCRIPTION: This function is needed to identify the weekday of the last eveny of the weekly period
+// In order to correctly identify the last recurrence date
+// (Example: event start date on a Monday, but repeats on Mondays and Fridays)
+// (Example cont.: so the last day will be a Friday, different from the original starting weekday)
+export function calibrateEndWeekday (startingDate, endingDate, days, recurrenceEndDate) {
+  const weekDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+  let daysOrdered = days
+  if (days) daysOrdered = weekDays.filter((e) => days.indexOf(e) >= 0)
+
+  const startingWeekday = startingDate.getDay()
+  let endingWeekday = endingDate.getDay()
+  if (daysOrdered) endingWeekday = weekDays.indexOf(daysOrdered[daysOrdered.length - 1])
+  const weekdayShift = endingWeekday - startingWeekday
+  const modifiedDate = new Date(recurrenceEndDate) || null
+  if (recurrenceEndDate) modifiedDate.setDate(recurrenceEndDate.getDate() + weekdayShift)
+
+  return modifiedDate
+}
+
+// DESCRIPTION: Takes event date object and resets to first preceeding weekday included in repeating 'days' array
+// PURPOSE: User may have specified a set of weekdays different from the event's start date
+//          This means we need to recalibrate the date before we can iterate to find the next event
+function resetEventWeekday (eventInstance, selectedDaysArray, allWeekdays) {
+  let weekday = eventInstance.getDay()
+  let modifiedDate = new Date(eventInstance)
+  modifiedDate.setDate(modifiedDate.getDate() - weekday)
+  while (!selectedDaysArray.includes(allWeekdays[modifiedDate.getDay()])) {
+    modifiedDate = new Date(modifiedDate.setDate(modifiedDate.getDate() + 1))
+  }
+  return modifiedDate
+}
+
+function jumpToNextWeekdayInPeriod (eventInstance, selectedDaysArray, allWeekdays) {
+  const weekday = eventInstance.getDay()
+  const weekdayName = allWeekdays[weekday]
+  const positionInPeriod = selectedDaysArray.indexOf(weekdayName)
+  const nextWeekday = allWeekdays.indexOf(selectedDaysArray[positionInPeriod + 1])
+  const jumpDays = nextWeekday - weekday
+  let modifiedDate = new Date(eventInstance.setDate(eventInstance.getDate() + jumpDays))
+  return modifiedDate
+}
+
+function jumpToNextWeek (eventInstance, periodSkip, selectedDaysArray, allWeekdays) {
+  const weekday = eventInstance.getDay()
+  const firstWeekdayName = selectedDaysArray[0]
+  const firstWeekday = allWeekdays.indexOf(firstWeekdayName)
+  const jumpDays = 7 * periodSkip + firstWeekday - weekday
+  let modifiedDate = new Date(eventInstance.setDate(eventInstance.getDate() + jumpDays))
+  return modifiedDate
+}
+
+function jumpToNextMonth (eventInstance, periodSkip, selectionType, selectionValue, firstDate) {
+  let modifiedDate = new Date(eventInstance)
+  const currentMonth = modifiedDate.getMonth() // 0-11
+  modifiedDate.setMonth(currentMonth + periodSkip)
+  if (selectionType === 'byDayInMonth') {
+    modifiedDate.setDate(selectionValue)
+  } else if (selectionType === 'byPosition') {
+    modifiedDate.setDate(1)
+    const actualWeekdayIndex = modifiedDate.getDay()
+    const desiredWeekdayIndex = firstDate.getDay()
+    const weekdayShift = desiredWeekdayIndex - actualWeekdayIndex >= 0 ?
+      desiredWeekdayIndex - actualWeekdayIndex
+      : 7 + desiredWeekdayIndex - actualWeekdayIndex
+    modifiedDate = new Date(modifiedDate.setDate(modifiedDate.getDate() + weekdayShift + (7 * (selectionValue - 1))))
+  } else {
+    throw new Error('Error parsing monthly recurrence type')
+  }
+  return modifiedDate
+}


### PR DESCRIPTION
**Changes:**
1 - Should finally resolve the [creating weekly events without selecting a weekday bug](https://trello.com/c/VXmZkc08/494-bug-user-can-post-event-recurring-every-week-ignoring-day-of-the-week-field-subsequent-event-page-causes-crash). I had to change approach slightly: previously had implemented a 'default weekday' auto-selected, but this was causing problems with the buttons, and also the user could still deselect and submit a blank form. Now there is no default, however the field is required and the user will get an error message instead (screenshot 1).

2 - date/time module has been redesigned as parts were incomplete. If an event is repeating, the box will display when is the next event from today, followed at the bottom by a description of the schedule and end date where applicable (screenshot 2 - this was one of the more convoluted example I tested, to check that it could compute the correct end date based on user inputs from the form. Normally the events will be simpler than this). One-time events should be unchanged from before

Any questions let me know. There's a lot of code that goes into finding the next Date (because of all the different recurrence options) so I've got on my to-do list to add some tests into the codebase once the existing tests are repaired.
 
ps - the form also presents the option to create an event 'on specific days of each week' - this is saved on the database differently from the above type of recurrence, so I haven't touched this piece yet, but hope to bring the two ways into alignment in the future.

**Screenshot 1**
![screenshot from 2019-02-28 23-55-27](https://user-images.githubusercontent.com/26905074/53607117-47216100-3bb5-11e9-90dd-10cc036b95ed.png)

**Screenshot 2**
![screenshot from 2019-02-28 18-58-55](https://user-images.githubusercontent.com/26905074/53607184-95cefb00-3bb5-11e9-994d-1f6e80f56f0e.png)
