### PR TITLE
Bugfix: Attempting to edit event to recur breaks the app (master)

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -323,10 +323,15 @@ const EventsSchema = new SimpleSchema({
     custom: function () {
       if (this.siblingField('forever').value) {
         return undefined
+      } else if (!this.value && !this.siblingField('until').value) {
+        return 'required'
       }
     },
     autoValue: function () {
       if (this.siblingField('forever').value) {
+        return null
+      }
+      if (this.siblingField('until').value) {
         return null
       }
     }
@@ -349,7 +354,12 @@ const EventsSchema = new SimpleSchema({
   },
   'when.recurring.until': {
     type: Date,
-    optional: true
+    optional: true,
+    custom: function () {
+      if (!this.value && !this.siblingField('occurences').value && !this.siblingField('forever').value) {
+        return 'required'
+      }
+    }
   },
 
   // Description and More

--- a/imports/client/ui/components/HoursFormatted/index.js
+++ b/imports/client/ui/components/HoursFormatted/index.js
@@ -103,8 +103,9 @@ const HoursFormatted = ({ data }) => {
     if (type === 'day') {
       return (
         <ul className='hours-formatted repeat'>
-          {(forever == true) && nextOccurence}
+          {(forever === true) && nextOccurence}
           {(!forever && recurrenceEndDate && new Date() < recurrenceEndDate) && nextOccurence}
+          {(!forever && until && new Date() < until) && nextOccurence}
           <li>{repeatTitle} {repeatSchedule}, between {startingTime} - {endingTime} </li>
           {!forever && notForeverDay}
         </ul>
@@ -112,21 +113,22 @@ const HoursFormatted = ({ data }) => {
     } else if (type === 'week') {
       return (
         <ul className='hours-formatted repeat'>
-          {(forever == true) && nextOccurence}
+          {(forever === true) && nextOccurence}
           {(!forever && recurrenceEndDate && new Date() < recurrenceEndDate) && nextOccurence}
+          {(!forever && until && new Date() < until) && nextOccurence}
           <li>
             <span className='every-sentence'>{repeatTitle} {repeatSchedule}</span><br/>
             {daysOrdered.map((day, index) => (
               day &&
                 <div key={index} className='day'>
-                <span>on {day.substr(0, 3)}, {startingTime} - {endingTime}</span><br/>
+                  <span>on {day.substr(0, 3)}, {startingTime} - {endingTime}</span><br/>
                 </div>
             ))}
           </li>
           {!forever && notForeverWeek}
         </ul>
       )
-    } else if (type === 'month'){
+    } else if (type === 'month') {
       return (
         <ul className='hours-formatted repeat'>
           {nextOccurence}

--- a/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/DateTimeModule/Recurring/index.js
@@ -18,9 +18,13 @@ class Recurring extends Component {
     } = this.props
 
     const model = form.getModel()
-    const {
+    let {
       recurring
     } = model.when
+
+    // NOTE: If this was previously a one-time event, being changed to recurring...
+    // ...then 'recurring' ibject is null, so we re-initialise:
+    if (!recurring) recurring = {}
 
     let forever = recurring.forever
     let monthly = recurring.monthly


### PR DESCRIPTION
**Main fix**: [this issue when trying to change event from one-time to recurring](https://trello.com/c/Xmi9uZV2/491-bug-attempting-to-edit-event-to-recur-breaks-the-app). (the problem was that when you submit a form for a one time event, it saves the 'recurring' field as null in the db, which threw an error when the subsequent edit tries to attach data onto the null object).
=> Added a conditional to replace null object with empty object when changing the event to recur.

**Additional small fix**: noticed that the form also allows you to leave both 'number of repeats', and 'until' fields blank when you are asked to provide an end date to a recurring, not-forever event (so you end up with a blank end date). On the other hand, it also lets you enter data in _both_ and submit (so you have conflicting end dates in the db).
=> Made the form require you to complete at least _one_ of the fields when the event is recurring and non-forever. If the user fills in _both_, the db will prioritise the provided 'until' date over the 'number of repeats'.