### PR TITLE
default to open-ended ending date for special category events (master)

### DIFF
--- a/imports/both/collections/events/helpers/index.js
+++ b/imports/both/collections/events/helpers/index.js
@@ -26,7 +26,6 @@ export const startingDate = {
 
 export const endingDate = {
   type: Date,
-  defaultValue: getDate(3),
   optional: true
 }
 
@@ -51,7 +50,7 @@ export function getHour (hours, date = new Date()) {
   return '15:00'
 }
 
-function getDate (hours) {
+export function getDate (hours) {
   let date = new Date()
 
   if (hours) {

--- a/imports/client/ui/components/HoursFormatted/index.js
+++ b/imports/client/ui/components/HoursFormatted/index.js
@@ -152,14 +152,18 @@ const HoursFormatted = ({ data }) => {
   }
 
   // DESCRIPTION: if !data.repeat then default view is start + end timestamp
+  const endFragment = (
+    isSameDay ? endingTime
+      : <div>
+        {formatDateWithWords(endingDate)}, {endingTime}
+      </div>
+  )
+  const ongoing = endingDate.getFullYear() - startingDate.getFullYear() > 5
+
   return (
     <div className='hours-formatted regular-date'>
-      <span>{formatDateWithWords(startingDate)}, {startingTime} - </span>
-      {isSameDay ? endingTime
-        : <div>
-          {formatDateWithWords(endingDate)}, {endingTime}
-        </div>
-      }
+      <span>{ongoing && `From`} {formatDateWithWords(startingDate)}, {startingTime} - </span>
+      {ongoing ? `until further notice` : endFragment}
     </div>
   )
 }

--- a/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { CustomInput, Row, Col } from 'reactstrap'
+import { CustomInput, Row, Col, Input, Label } from 'reactstrap'
 import labels from '/imports/both/i18n/en/new-event-modal.json'
 import AutoField from '/imports/client/utils/uniforms-custom/AutoField'
 import ErrorField from '/imports/client/utils/uniforms-custom/ErrorField'
@@ -10,6 +10,14 @@ import SameDateHours from './SameDateHours'
 
 
 class SecondStep extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      openEndDate: this.props.form.getModel().categories.some(e => {
+        return e.name === 'Community Offer' || e.name === 'Meet me for Action!'
+      })
+    }
+  }
   render () {
     const {
       form
@@ -17,11 +25,14 @@ class SecondStep extends Component {
 
     const RadioButton = this.RadioButton
 
+    let { openEndDate } = this.state
+
     const {
       days,
       multipleDays,
       repeat
     } = form.getModel().when
+
     return (
       <div id='second-step'>
         <AutoField name='findHints' />
@@ -33,8 +44,20 @@ class SecondStep extends Component {
                 {!multipleDays && <AutoField name='when.startingTime' />}
               </Col>
               <Col className='date-hours-coupled'>
-                {!repeat && <AutoField name='when.endingDate' />}
-                {!multipleDays && <AutoField name='when.endingTime' />}
+                {(!repeat && !openEndDate) && <AutoField
+                  name='when.endingDate'
+                  specialCat={this.props.form.getModel().categories.some(e => {
+                    return e.name === 'Community Offer' || e.name === 'Meet me for Action!'
+                  })}
+                />}
+                {(!multipleDays && !openEndDate) && <AutoField name='when.endingTime' />}
+                {(!repeat && openEndDate) && (
+                  <AutoField
+                    name='when.endingDate'
+                    openEndDate={true}
+                    handleCalendarClick={this.resetEndDate}
+                  />
+                )}
               </Col>
             </Row>
           </div>
@@ -87,6 +110,11 @@ class SecondStep extends Component {
       </div>
     )
   }
+
+resetEndDate = () => {
+  // NOTE: for special category events, this resets their ending date to standard
+  this.setState({ openEndDate: false })
+}
 
 RadioButton = ({ label, id, value, type }) => (
   <CustomInput

--- a/imports/client/utils/format.js
+++ b/imports/client/utils/format.js
@@ -115,6 +115,10 @@ export function formatWhenObject (data) {
     }
   }
 
+  if (endingDate.getFullYear() - startingDate.getFullYear() > 5) {
+    return `from ${formatDate(startingDate)}, ${startingTime} until further notice`
+  }
+
   return `from ${formatDate(startingDate)}, ${startingTime} until ${formatDate(endingDate)}, ${endingTime}`
 }
 

--- a/imports/client/utils/uniforms-custom/DateField.js
+++ b/imports/client/utils/uniforms-custom/DateField.js
@@ -91,18 +91,19 @@ class Date_ extends Component {
   }
 
   render() {
-    const { id, label, onChange, value, error, placeholder } = this.props;
-    const { showDayPicker } = this.state;
+    const { id, label, onChange, value, error, openEndDate, name, specialCat } = this.props
+    const { showDayPicker } = this.state
 
     return (
       <FormGroup className="date-field">
         <Label>{label}</Label>
         <Input
           id={id}
-          value={formatDate(value)}
+          value={this.dateValue(openEndDate, specialCat, name, value)}
           onFocus={e => this.toggleDayPicker(e, true)}
           invalid={Boolean(error)}
           onChange={onChange} // <------Input isn't being changed.
+          onClick={this.props.handleCalendarClick}
         />
         <Modal
           isOpen={showDayPicker}
@@ -130,6 +131,9 @@ class Date_ extends Component {
     );
   }
 
+  // NOTE: if openEnded is true => event defaults to ongoing/quasi-forever
+  dateValue = (openEndDate, specialCat, name, value) => openEndDate ? 'Leave Blank for Always' : formatDate(specialCat, name, value)
+
   handleChange = (date = null) => {
     this.toggleDayPicker();
     this.props.onChange(date);
@@ -145,9 +149,15 @@ class Date_ extends Component {
   };
 }
 
-const formatDate = date => {
+const formatDate = (specialCat, name, date) => {
+  // NOTE: if no default date object is passed => render blank space (eg. 'until' field)
+  // BUT: to prepopulate without default value from form => create local date obj
+  let prepopDate = name === 'when.recurring.until' || !!date ?
+    date : new Date(new Date().setHours(new Date().getHours() + 3))
+  // NOTE: if the field belongs to a special category, we leave it blank
+  if (specialCat && !date) prepopDate = ""
   try {
-    return date
+    return prepopDate
       .toISOString()
       .substring(0, 10)
       .split("-")


### PR DESCRIPTION
relates to [this issue](https://trello.com/c/zQDzkGbT/505-create-always-button-on-time-date-modal-and-set-the-special-category-to-default-to-it) 
Fix ended up being more fiddly than I expected because of how the form, database and React interact with one another... Let me know if any of the below doesn't make sense/you prefer a different solution. As mentioned below I decided to have the calendar input itself double up as the "always" button instead of having an extra button as suggested in the trello task, because adding a new one was breaking the formatting for the rest of the boxes/columns.

**User summary:**
- When user selects meet me for action/community offers, the end date calendar will display the info message 'Leave blank for Always' (screenshot 1)
- Leaving it untouched will populate the db with an end date of now + 10 years. In the UI the ending date (2029) will not explicitly be shown, instead it will display the start date +  'until further notice' (screenshot 2)
- Focusing on the calendar input once will remove the info message (and leave a blank space), and once the user clicks and selects a date in the calendar, this will over-write the + 10 year default
- If user selects a recurrence schedule e.g. repeat once a week etc, this will also disable the + 10 years: instead it will default to a regular time slot to prevent conflict with recurrence schedule.

**Screenshot 1**
![screenshot from 2019-03-04 23-52-50](https://user-images.githubusercontent.com/26905074/53791302-f6956500-3f20-11e9-8c81-55c2476d7f1b.png)

**Screenshot 2**
![screenshot from 2019-03-05 00-13-13](https://user-images.githubusercontent.com/26905074/53791324-090f9e80-3f21-11e9-95f3-046792c56df4.png)