### PR TITLE
Included video player in page heading (master)

### DIFF
--- a/imports/both/i18n/en/video.json
+++ b/imports/both/i18n/en/video.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "Positive Action Road Trips",
+    "categories": ["default"],
+    "playlistID": "PLzwMXFvS_OYOkzU_-WFYMoPuwPi0QNsvN",
+    "videoCount": 55,
+    "videos": ["QOcUj-i27c0", "7sLnprRKlRs", "pztlvfFvbOg", "l1OjVuM9sw8", "gBsac75-_BE", "3QNbxSOHsJg", "NIp0BsbnRME", "Zwh73pK4Gjk", "S96b0scuJNY", "xdMaGmRsw2w", "arRGByG8VhA", "u4P9WH4kLeE", "Pm8VFDTxCjE", "OZoToon27jY", "SimctE871_Y", "Ty2tFX-VxuM", "TrckaUlyVdI", "_h6Dl8_Ydlc", "oVjEE4_p_gk", "5EM9Q0gSd2I", "nWvFFe0LncA", "NgDlI2fKXYs", "gktBQ0g0MyY", "2a3UAfo_V4Q", "0YNQDQFla-0", "o9prVD8SxAY", "An-Cn2hF_c4", "GOU_QG_jyo8", "N0B4CL0GIpU", "H6r-4ES5Q1g", "43ljDVbSHrM", "9KjWCCFQL4U", "Zk-AlA0ME5E", "DfQ4nb_f0zc", "xoxl0TQJ8sA", "81fvjrQ3NnU", "H61KsHk_cbo", "_WpVvzEslis", "GndO0bUElrQ", "tG4l514O0t4", "ivgvIUAGlHU", "fhZcXNz2NBU", "HjZEGClu7R0", "lIjb5Cz1ihQ", "D8WW5sRQGQA", "2Zn1nFAMuII", "XWtOdVkXxzs", "JM8YsfI65v0", "tjRlmwshHRc", "R1utLiOgnDU", "XcUy8zBfcik", "LhRBsR_8Bvw", "1b2LA84Wc4I", "CCpdL4UZ2So", "MdLzHCgzPdk"]
+  },
+  {
+    "name": "Bubble Blow Flash Mob",
+    "categories": ["default", "Give a Bubble"],
+    "playlistID": "PLzwMXFvS_OYOQilLBT4RVOTx1X2PmfSti",
+    "videoCount": 19,
+    "videos": ["TdAv0V2ju_o", "s3A307zQJk4", "LhRBsR_8Bvw", "XcUy8zBfcik", "n1LGKGdAGRw", "N6zHhIWsk5E", "qt-H8MlQVfQ", "-f-Q555_unY", "x2alMviEo6M", "HjZEGClu7R0", "Rv1pBE9G6cM", "H61KsHk_cbo", "81fvjrQ3NnU", "xoxl0TQJ8sA", "DfQ4nb_f0zc", "An3_0xOyfzM", "RERtipoEH90", "jEK3PlkIw2g", "_D7cL5v_3qg"]
+  },
+  {
+    "name": "Free Hugs",
+    "categories": ["default", "Free Hugs"],
+    "playlistID": "PLzwMXFvS_OYND-Tm2a6404bvaEzrXPdXm",
+    "videoCount": 42,
+    "videos": ["s5nYVd5ASRg", "YXU4GOUjzzA", "A5miqNfcIY0", "PnHiYbLzJAg", "nNso-FQ9iUg", "YyVq5pgWpI8", "bNqFAiMM3-8", "DDoHZqzNsmY", "QXeC16VCuP4", "fNVP95Wu-_U", "kpb4l7IjKPY", "9KjWCCFQL4U", "43ljDVbSHrM", "H6r-4ES5Q1g", "DyaajCLn8rA", "kNobe7USVCc", "7dOtdy1ZJ7s", "-SuOMZawikE", "lnTGZaGoFEs", "S96b0scuJNY", "arRGByG8VhA", "-wvfeNK3WMk", "HDQPmN_3NaA", "rYg-E7Qm39s", "0YNQDQFla-0", "o9prVD8SxAY", "gktBQ0g0MyY", "2a3UAfo_V4Q", "oVjEE4_p_gk", "v4X-qtYslBM", "ZqDSEbV47e4", "wJB5LWp7xKs", "S9m_looK3Co", "M_scUflMbY4", "olOzNQyte2M", "YWpodVZ5shg", "u4P9WH4kLeE", "NIp0BsbnRME", "3QNbxSOHsJg", "gBsac75-_BE", "l1OjVuM9sw8", "7sLnprRKlRs"]
+  },
+  {
+    "name": "Public Music Jam",
+    "categories": ["default", "Public Music Jam", "Busker Dance Party", "Public Dancing"],
+    "playlistID": "PLzwMXFvS_OYNYqw4ZQK5Sh0iXjym2c9Lp",
+    "videoCount": 18,
+    "videos": ["1b2LA84Wc4I", "wzX7M7yCBNc", "tZoqYd2agNE", "l29TRV1CvyI", "DAYV7ERoO00", "wnL-_dfvxxs", "eaSuVpCJMwM", "89RNNJ7tIwA", "N-YmAgyAcQg", "t9xbR3WxzPA", "_pexSpq9aiI", "hBWgJQxxmqY", "5Zyf-rWGZkI", "-VbjUBN7sC4", "qq_b8VmYQ3U", "B7giDZhXbho", "BTBUqFqmIXY", "KvskJC9bD00"]
+  },
+  {
+    "name": "Open Skills Sharing",
+    "categories": ["default"],
+    "playlistID": "PLzwMXFvS_OYPOIGeR9sM58sNW9U04qsAd",
+    "videoCount": 11,
+    "videos": ["CAgtXQaoMpg", "YqaAHD1sm_A", "d5zEeFbxz7E", "xMG_EvnTiDo", "m0SLX98VP34", "N0B4CL0GIpU", "GOU_QG_jyo8", "3r1DVyyIIcE", "_JuDK6Kfs6c", "UKsj_6WEkzQ", "t78G-hc8ppE"]
+  },
+  {
+    "name": "Pillow Fight 4 Connection",
+    "categories": ["default", "Pillow Fight 4Connection"],
+    "playlistID": "PLzwMXFvS_OYNtATdZWjvTNs-CsEG-KedB",
+    "videoCount": 67,
+    "videos": ["CCpdL4UZ2So", "WUppGn2Z4b4", "MrgydNUEo40", "wyMLKTdwJTo", "tjRlmwshHRc", "JM8YsfI65v0", "2jIOQ5Wew-c", "FWUwtUAnOKg", "SZsxGwQPa_c", "c52cCn5xYLw", "2Zn1nFAMuII", "D8WW5sRQGQA", "lIjb5Cz1ihQ", "fhZcXNz2NBU", "ivgvIUAGlHU", "_JLXKb0Kkds", "GndO0bUElrQ", "_WpVvzEslis", "q0tNmrsbmoU", "2NVsyhjDYQY", "Dnm7xXMz3WI", "X7X80GoT5lU", "nYXZvGiTkKU", "KgfAGHEJ1_Q", "amLxetDY4Gk", "a5pULjDKeZQ", "vRknKFE5OGI", "o_ki5E9NOwI", "8zpaonA4Vps", "iv6Sij7OoTc", "52LjtUIAeNE", "8XmgJVQdyCw", "9hY0y6CJVDU", "kJnGfPB0rYI", "7LQYWYjnWYQ", "5w5qTeObLsY", "MNGbXNw0soY", "3_lhd6rexkY", "63rImflGTxk", "2VF-yIJqYQs", "G0ck6H21EjY", "-UTTL14W4go", "mDLpFJvWcW4", "LkexCLnihic", "dv9VjSXbzps", "8VfwQeZU5_I", "Lyf-9ZM8EyQ", "cjgYB273TN4", "vd3Ri2Kpytg", "yGCktskIYJ0", "2ExB64gANIo", "I_tZi1-dFY0", "SeRN0deP5QU", "MEZgblUQebQ", "An-Cn2hF_c4", "NgDlI2fKXYs", "nWvFFe0LncA", "UN5IvOJ-1QY", "ZfFanE_D9aI", "Cm3pQBtOxUk", "odmP7Ow_W5I", "P8FxP5_ICkY", "52bTCB1DaEE", "tKMInSPJl3I", "Zrpl1XWTGBE", "nkLX65yeiUs", "k1adYovOzog"]
+  },
+  {
+    "name": "Take a Smile",
+    "categories": ["default", "Take a Smile"],
+    "playlistID": "PLzwMXFvS_OYOZHFwIXp_fE68860wOJWdw",
+    "videoCount": 19,
+    "videos": ["v5FuQa-9mLQ", "ibdSUhMmVbk", "R1utLiOgnDU", "wYwlkUdaoE4", "cJi_JJYbC3Y", "_h6Dl8_Ydlc", "SimctE871_Y", "N1biJ4LYmDA", "SPRjr-ChLdw", "5EM9Q0gSd2I", "1XRVS5uxpeU", "OZoToon27jY", "Pm8VFDTxCjE", "rqhcvhx_Pco", "TrckaUlyVdI", "y2nzz5HW9BE", "Ty2tFX-VxuM", "VrWGdXPmBD8", "CmLI6x0aMRQ"]
+  },
+  {
+    "name": "International Pillow Fight Day London 2014",
+    "categories": ["default", "Pillow Fight 4Connection"],
+    "playlistID": "PLzwMXFvS_OYPk2E_4dwIxrRqFcB4iqLSl",
+    "videoCount": 24,
+    "videos": ["a5pULjDKeZQ", "2NVsyhjDYQY", "nYXZvGiTkKU", "X7X80GoT5lU", "o_ki5E9NOwI", "kJnGfPB0rYI", "5w5qTeObLsY", "7LQYWYjnWYQ", "8zpaonA4Vps", "iv6Sij7OoTc", "8XmgJVQdyCw", "52LjtUIAeNE", "7TM6l1p17S8", "AyKx6qhcxqE", "lcsuTVUbAa8", "SZ9UpB-rPp8", "SZsxGwQPa_c", "fqWYur4WcPE", "way0lsR_hm0", "-V9sSs-pDAQ", "YEmvHjdoWd0", "owu_Zf8Kong", "MrgydNUEo40", "Tx3d0GetA7M"]
+  },
+  {
+    "name": "Community Slip and Slide",
+    "categories": ["default"],
+    "playlistID": "PLzwMXFvS_OYOlujizzDYNvvRn-P8OnXVD",
+    "videoCount": 1,
+    "videos": ["35zrVo_QtrM"]
+  },
+  {
+    "name": "Kindness Auction and BBQ",
+    "categories": ["default"],
+    "playlistID": "PLzwMXFvS_OYMLCH8PFgD9p1EdQLc1MlV-",
+    "videoCount": 13,
+    "videos": ["Wnr17Ed547s", "odmP7Ow_W5I", "ngCbB0UtN7o", "_JiVUAjmbxY", "_JuDK6Kfs6c", "3r1DVyyIIcE", "UKsj_6WEkzQ", "t78G-hc8ppE", "v4X-qtYslBM", "ZqDSEbV47e4", "Cm3pQBtOxUk", "ZfFanE_D9aI", "UN5IvOJ-1QY"]
+  }
+]

--- a/imports/client/ui/components/VideoPlayer/index.js
+++ b/imports/client/ui/components/VideoPlayer/index.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react'
+import ReactPlayer from 'react-player/lib/players/YouTube'
+import './styles.scss'
+
+const playlists = {
+  'Positive Action Road Trips': 'PLzwMXFvS_OYOkzU_-WFYMoPuwPi0QNsvN',
+  'Bubble Blow Flash Mob': 'PLzwMXFvS_OYOQilLBT4RVOTx1X2PmfSti',
+  'Free Hugs': 'PLzwMXFvS_OYND-Tm2a6404bvaEzrXPdXm',
+  'Public Music Jam': 'PLzwMXFvS_OYNYqw4ZQK5Sh0iXjym2c9Lp',
+  'Open Skills Sharing': 'PLzwMXFvS_OYPOIGeR9sM58sNW9U04qsAd',
+  'Pillow Fight 4 Connection': 'PLzwMXFvS_OYNtATdZWjvTNs-CsEG-KedB',
+  'Take a Smile': 'PLzwMXFvS_OYOZHFwIXp_fE68860wOJWdw',
+  'International Pillow Fight Day London 2014': 'PLzwMXFvS_OYPk2E_4dwIxrRqFcB4iqLSl',
+  'Community Slip and Slide': 'PLzwMXFvS_OYOlujizzDYNvvRn-P8OnXVD',
+  'Kindness Auction and BBQ': 'PLzwMXFvS_OYOlujizzDYNvvRn-P8OnXVD'
+}
+
+const categoryPlaylist = [
+  { 'name': 'Meet me for Action!', 'color': 'red', 'default': true, 'url': '' },
+  { 'name': 'Global Flash Mobs', 'color': '#38a80d', 'url': '' },
+  { 'name': 'Be Happier Community Meet', 'color': '#18a80d', 'url': '' },
+  { 'name': 'Free Hugs', 'color': '#f82d2d', 'url': 'https://news.focallocal.org/free-hugs/' },
+  { 'name': 'Pillow Fight 4Connection', 'color': '#48a80d', 'url': 'https://news.focallocal.org/pillow-fight4connection/' },
+  { 'name': 'Give a Bubble', 'color': '#0ea575', 'url': 'https://news.focallocal.org/give-a-bubble/' },
+  { 'name': 'Take a Smile', 'color': '#0e77a3', 'url': 'https://news.focallocal.org/take-a-smile/' },
+  { 'name': 'Public Dancing', 'color': '#6512bc', 'url': '' },
+  { 'name': 'Public Music Jam', 'color': '#a711c4', 'url': '' },
+  { 'name': "I've Got a Message for YOU!", 'color': '#fc1976', 'url': 'https://news.focallocal.org/ive-got-a-message-for-you-the-positive-thinking-jar/' },
+  { 'name': 'The Positivity Facilitator', 'color': '#080fba', 'url': 'https://news.focallocal.org/the-positivity-facilitator/' },
+  { 'name': 'Inspire MY City', 'color': '#e5a20b', 'url': 'https://news.focallocal.org/musical-connection/transport-jam/' },
+  { 'name': 'Eye Bombing', 'color': '#43a904', 'url': '' },
+  { 'name': 'Connecting Canvas', 'color': '#ce1ca4', 'url': 'https://news.focallocal.org/connecting-canvas/' },
+  { 'name': 'Guerrilla Urban Beautification', 'color': '#1f482d', 'url': 'https://news.focallocal.org/community-guerrilla-gardening/' },
+  { 'name': 'Open Skills Sharing Day', 'color': '#52929b', 'url': 'https://news.focallocal.org/international-open-skills-sharing-day/' },
+  { 'name': 'Pick-me-up Public Poetry', 'color': '#6d65bc', 'url': '' },
+  { 'name': 'Busker Dance Party', 'color': '#5e9e6b', 'url': '' },
+  { 'name': 'Something Else', 'color': '#1a61ef', 'url': '' },
+  { 'name': 'Good Human Appreciation', 'color': '#4a0bff', 'url': '' },
+  { 'name': 'Eye Contact for Connection', 'color': '#adbc12', 'url': 'https://news.focallocal.org/eye-contact-gathering/' },
+  { 'name': 'Health + Well-being Flash', 'color': '#5e9b6b', 'url': '' },
+  { 'name': 'Gather for More Happiness', 'color': '#63d85b', 'url': '' },
+  { 'name': 'Supporting with my Skills', 'color': '#f57c00', 'url': '' },
+  { 'name': 'Taking a Break', 'color': '#d7191c', 'url': '' }
+]
+
+class VideoPlayer extends Component {
+  render () {
+    let url = 'xxx'
+    let playlistID = playlists['Take a Smile']
+    const { categories } = this.props
+    if (true) {
+    // if (categories.some((e) => e.name === 'Free Hugs')) {
+      url = `https://www.youtube.com/playlist?list=${playlistID}
+      &modestbranding=1
+      &rel=0`
+    }
+
+    return (
+      <div className="videoContainer">
+        <ReactPlayer
+          className="videoPlayer"
+          url={url}
+          width='100%'
+          height='100%'
+          volume={0.5}
+          playing
+        />
+      </div>
+    )
+  }
+}
+
+export default VideoPlayer

--- a/imports/client/ui/components/VideoPlayer/index.js
+++ b/imports/client/ui/components/VideoPlayer/index.js
@@ -1,73 +1,81 @@
 import React, { Component } from 'react'
-import ReactPlayer from 'react-player/lib/players/YouTube'
+import ReactPlayer from 'react-player'
 import './styles.scss'
-
-const playlists = {
-  'Positive Action Road Trips': 'PLzwMXFvS_OYOkzU_-WFYMoPuwPi0QNsvN',
-  'Bubble Blow Flash Mob': 'PLzwMXFvS_OYOQilLBT4RVOTx1X2PmfSti',
-  'Free Hugs': 'PLzwMXFvS_OYND-Tm2a6404bvaEzrXPdXm',
-  'Public Music Jam': 'PLzwMXFvS_OYNYqw4ZQK5Sh0iXjym2c9Lp',
-  'Open Skills Sharing': 'PLzwMXFvS_OYPOIGeR9sM58sNW9U04qsAd',
-  'Pillow Fight 4 Connection': 'PLzwMXFvS_OYNtATdZWjvTNs-CsEG-KedB',
-  'Take a Smile': 'PLzwMXFvS_OYOZHFwIXp_fE68860wOJWdw',
-  'International Pillow Fight Day London 2014': 'PLzwMXFvS_OYPk2E_4dwIxrRqFcB4iqLSl',
-  'Community Slip and Slide': 'PLzwMXFvS_OYOlujizzDYNvvRn-P8OnXVD',
-  'Kindness Auction and BBQ': 'PLzwMXFvS_OYOlujizzDYNvvRn-P8OnXVD'
-}
-
-const categoryPlaylist = [
-  { 'name': 'Meet me for Action!', 'color': 'red', 'default': true, 'url': '' },
-  { 'name': 'Global Flash Mobs', 'color': '#38a80d', 'url': '' },
-  { 'name': 'Be Happier Community Meet', 'color': '#18a80d', 'url': '' },
-  { 'name': 'Free Hugs', 'color': '#f82d2d', 'url': 'https://news.focallocal.org/free-hugs/' },
-  { 'name': 'Pillow Fight 4Connection', 'color': '#48a80d', 'url': 'https://news.focallocal.org/pillow-fight4connection/' },
-  { 'name': 'Give a Bubble', 'color': '#0ea575', 'url': 'https://news.focallocal.org/give-a-bubble/' },
-  { 'name': 'Take a Smile', 'color': '#0e77a3', 'url': 'https://news.focallocal.org/take-a-smile/' },
-  { 'name': 'Public Dancing', 'color': '#6512bc', 'url': '' },
-  { 'name': 'Public Music Jam', 'color': '#a711c4', 'url': '' },
-  { 'name': "I've Got a Message for YOU!", 'color': '#fc1976', 'url': 'https://news.focallocal.org/ive-got-a-message-for-you-the-positive-thinking-jar/' },
-  { 'name': 'The Positivity Facilitator', 'color': '#080fba', 'url': 'https://news.focallocal.org/the-positivity-facilitator/' },
-  { 'name': 'Inspire MY City', 'color': '#e5a20b', 'url': 'https://news.focallocal.org/musical-connection/transport-jam/' },
-  { 'name': 'Eye Bombing', 'color': '#43a904', 'url': '' },
-  { 'name': 'Connecting Canvas', 'color': '#ce1ca4', 'url': 'https://news.focallocal.org/connecting-canvas/' },
-  { 'name': 'Guerrilla Urban Beautification', 'color': '#1f482d', 'url': 'https://news.focallocal.org/community-guerrilla-gardening/' },
-  { 'name': 'Open Skills Sharing Day', 'color': '#52929b', 'url': 'https://news.focallocal.org/international-open-skills-sharing-day/' },
-  { 'name': 'Pick-me-up Public Poetry', 'color': '#6d65bc', 'url': '' },
-  { 'name': 'Busker Dance Party', 'color': '#5e9e6b', 'url': '' },
-  { 'name': 'Something Else', 'color': '#1a61ef', 'url': '' },
-  { 'name': 'Good Human Appreciation', 'color': '#4a0bff', 'url': '' },
-  { 'name': 'Eye Contact for Connection', 'color': '#adbc12', 'url': 'https://news.focallocal.org/eye-contact-gathering/' },
-  { 'name': 'Health + Well-being Flash', 'color': '#5e9b6b', 'url': '' },
-  { 'name': 'Gather for More Happiness', 'color': '#63d85b', 'url': '' },
-  { 'name': 'Supporting with my Skills', 'color': '#f57c00', 'url': '' },
-  { 'name': 'Taking a Break', 'color': '#d7191c', 'url': '' }
-]
+import allPlaylists from '/imports/both/i18n/en/video.json'
 
 class VideoPlayer extends Component {
-  render () {
-    let url = 'xxx'
-    let playlistID = playlists['Take a Smile']
-    const { categories } = this.props
-    if (true) {
-    // if (categories.some((e) => e.name === 'Free Hugs')) {
-      url = `https://www.youtube.com/playlist?list=${playlistID}
-      &modestbranding=1
-      &rel=0`
+  constructor (props) {
+    super(props)
+    this.state = {
+      nextVideo: false
     }
+  }
+
+  componentDidUpdate () {
+    this.setState({ nextVideo: false })
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    if (nextState.nextVideo === true) return true
+    // NOTE: otherwise the player will keep re-rendering on every page click
+    return false
+  }
+
+  render () {
+    const { categories } = this.props
 
     return (
-      <div className="videoContainer">
+      <div
+        className="videoContainer"
+      >
         <ReactPlayer
           className="videoPlayer"
-          url={url}
+          url={buildURL(categories)}
           width='100%'
           height='100%'
           volume={0.5}
           playing
+          // onEnded={this.setState({ nextVideo: true })}
+          onEnded={() => {
+            this.setState({ nextVideo: true })
+          }}
         />
       </div>
     )
   }
+}
+
+function buildURL (categories) {
+  const playlist = generatePlaylist(allPlaylists, categories, [])
+  const video = getRandomVideo(playlist)
+  const url = `https://www.youtube.com/watch?v=${video}&modestbranding=1&rel=0&disablekb=1`
+  return url
+}
+
+function getRandomVideo (playlist) {
+  const length = playlist.length
+  const randomIndex = Math.floor(Math.random() * length)
+  return playlist[randomIndex]
+}
+function generatePlaylist (playlists, eventCategories, outputArray) {
+  playlists.forEach((playlist) => {
+    eventCategories.forEach((eventCategory) => {
+      if (playlist.categories.includes(eventCategory.name)) {
+        playlist.videos.forEach((video) => {
+          if (!outputArray.includes(video)) {
+            outputArray.push(video)
+          }
+        })
+      }
+    })
+  })
+
+  // NOTE: if event category does not have a dedicated playlist then we generate default
+  if (outputArray.length === 0) {
+    generatePlaylist(playlists, [{ 'name': 'default' }], outputArray)
+  }
+
+  return outputArray
 }
 
 export default VideoPlayer

--- a/imports/client/ui/components/VideoPlayer/styles.scss
+++ b/imports/client/ui/components/VideoPlayer/styles.scss
@@ -1,6 +1,6 @@
 
 .videoContainer {
-  height: 150%;
+  height: 100%;
   padding-top: 56.25%;
   overflow: hidden;
   .videoPlayer {

--- a/imports/client/ui/components/VideoPlayer/styles.scss
+++ b/imports/client/ui/components/VideoPlayer/styles.scss
@@ -1,0 +1,12 @@
+
+.videoContainer {
+  height: 150%;
+  padding-top: 56.25%;
+  overflow: hidden;
+  .videoPlayer {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+}

--- a/imports/client/ui/pages/Page/index.js
+++ b/imports/client/ui/pages/Page/index.js
@@ -6,6 +6,7 @@ import { Container, Row, Col } from 'reactstrap'
 import { formatCategories } from '/imports/client/utils/format'
 import { scrollToElement } from '/imports/client/utils/DOMInteractions'
 import HoursFormatted from '/imports/client/ui/components/HoursFormatted'
+import VideoPlayer from '/imports/client/ui/components/VideoPlayer'
 import PageLoader from '/imports/client/ui/components/PageLoader'
 import EditPage from './Edit'
 // import AttendingButton from './AttendingButton'  <-- currently disabled
@@ -170,16 +171,19 @@ class Page extends Component {
     return (
       <div id='page' onClick={e => this.dcsClick(null, e)}>
         <div className='header'>
-          <div className='title-wrapper'>
-            <div className='title'>{name}</div>
-            <div className='sub-title-categories'>{categories}</div>
-          </div>
+          <VideoPlayer
+            categories={c}
+          />
         </div>
 
         <Container className='body'>
           <Row>
 
             <Col xs={7} className='left'>
+              <div className='title-wrapper'>
+                <div className='title'>{name}</div>
+                <div className='sub-title-categories'>{categories}</div>
+              </div>
               <div className='intro'>
                 <SectionTitle title='Introduction' />
                 <Linkify options={linkifyOption}>{overview}</Linkify>

--- a/imports/client/ui/pages/Page/style.scss
+++ b/imports/client/ui/pages/Page/style.scss
@@ -6,34 +6,11 @@ $titles-color: #fff;
   .header {
     position: relative;
     display: flex;
-    align-items: flex-end;
+    align-items: center;
     justify-content: center;
     height: 25vw;
     min-height: 250px;
     padding: 15px;
-    background: #f79d00; /* fallback for old browsers */
-    background: -webkit-linear-gradient(to top, #00c362, #f79d00); /* Chrome 10-25, Safari 5.1-6 */
-    background: linear-gradient(to top, #00c362, rgba(0, 0, 0, 0.35)); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
-
-    .title-wrapper {
-      width: 80%;
-      color: #fff;
-      font-weight: bolder;
-      word-wrap: break-word;
-      overflow: auto;
-    }
-
-    .title {
-      max-height: 156px;
-      font-size: 2.2rem;
-      overflow: auto;
-    }
-
-    .sub-title-categories {
-      max-height: 80px;
-      font-size: 1.4rem;
-      overflow: auto;
-    }
   }
 
   .body {
@@ -57,8 +34,29 @@ $titles-color: #fff;
         Left Column
        -------------- */
 
-    .left {
-      .intro, .meet-me, .description {
+    .left{
+
+      .title-wrapper {
+        width: 100%;
+        color: rgb(50, 52, 56);
+        font-weight: bolder;
+        word-wrap: break-word;
+        overflow: auto;
+      }
+
+      .title {
+        max-height: 156px;
+        font-size: 2.2rem;
+        overflow: auto;
+      }
+
+      .sub-title-categories {
+        max-height: 80px;
+        font-size: 1.4rem;
+        overflow: auto;
+      }
+
+      .intro, .meet-me, .description{
         margin: 20px 0;
       }
     }
@@ -69,6 +67,7 @@ $titles-color: #fff;
     .right {
       width: 300px;
       max-width: 300px;
+      padding-top: 15px;
 
       .hours-formatted {
         
@@ -211,6 +210,7 @@ $titles-color: #fff;
           max-width: 95%;
           flex: 0 0 100%;
           margin-bottom: 24px;
+          padding-right: 0;
         }
 
         .hours-formatted {

--- a/imports/client/ui/style.scss
+++ b/imports/client/ui/style.scss
@@ -11,6 +11,7 @@
     flex: 1 0 0;
     overflow-y: auto;
     transition: flex-grow 0s; // We use a transition only for the benefit of 'transition-delay'
+    scrollbar-width: thin; // this is for FireFox browsers, to fix the white gap between scrollbar and main page
   }
   &:not(.dcs-show-right) #dcs-right {
     flex-grow: 0;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-hot-loader": "^4.1.3",
     "react-loadable": "^5.4.0",
     "react-places-autocomplete": "^7.1.1",
+    "react-player": "^1.9.3",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-select": "^2.0.0-beta.2",


### PR DESCRIPTION
Added video player and made some visual adjustments to insert into the page header. Relates to [this issue on Trello](https://trello.com/c/udFhd40S/412-both-video-player-in-pages-header-section) however the link upload form functionality is still WIP

- Videos are chosen from the i18n file video.json, selected randomly from within individual playlists if playlists are matched with the event category on display, or from the entire selection of videos if there is no match found (e.g. free hugs will only play free hugs videos, but 'meet me for action' will pick a video from the entire focallocal channel at random)
- Once the video ends, a new random video will start. Youtube doesn't allow this natively, so I made it so the React component re-renders itself once a video ends.

Additional small tweak: fyi Firefox renders the scrollbar slightly thicker than other browsers, previously this would lead to a narrow white vertical gap next to the scroll that looks weird next to the black video player background. Removed this by adding the 'scrollbar-width' CSS field below. This is only recognised by Firefox (so if you see a warning in atom/your browser console related to this you don't need to worry about it)