### PR TITLE
Multiple fixes/formatting tweaks to video links submission (master)

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -443,19 +443,23 @@ const EventsSchema = new SimpleSchema({
     defaultValue: {}
   },
   'video.link1.host': {
+    optional: true,
     type: String,
-    // optional: true,
-    allowedValues: videoHosts.map((e) => `${e.host} (eg. ${e.prefix}<VIDEO_ID>)`),
+    defaultValue: labels.video.host,
     uniforms: {
       customType: 'select',
-      label: null
-    },
-    defaultValue: labels.video.host
+      label: null,
+      allowedValues: videoHosts.map((e) => `${e.host} (eg. ${e.prefix}<VIDEO_ID>)`),
+      selectOptions: {
+        url: true
+      },
+    }
   },
   'video.link1.address': {
+    optional: true,
     type: String,
     custom: function () {
-      if (this.siblingField('host').value && this.siblingField('host').value !== 'Select your video host from the dropdown') {
+      if (this.value && this.value !== "") {
         const host = this.siblingField('host').value.split(' (eg.')[0]  // <-- split out the 'example' at the end of host field text
         const prefixServer = videoHosts.find(e => e.host === host).prefix
         const prefixClient = this.value.slice(0, prefixServer.length)
@@ -464,27 +468,30 @@ const EventsSchema = new SimpleSchema({
     },
     uniforms: {
       label: null
-    },
-    defaultValue: labels.video.address
+    }
   },
   'video.link2': {
     type: Object,
     optional: true
   },
   'video.link2.host': {
+    optional: true,
     type: String,
-    // optional: true,
-    allowedValues: videoHosts.map((e) => `${e.host} (eg. ${e.prefix}<VIDEO_ID>)`),
+    defaultValue: labels.video.host,
     uniforms: {
       customType: 'select',
-      label: null
-    },
-    defaultValue: labels.video.host
+      label: null,
+      allowedValues: videoHosts.map((e) => `${e.host} (eg. ${e.prefix}<VIDEO_ID>)`),
+      selectOptions: {
+        url: true
+      },
+    }
   },
   'video.link2.address': {
+    optional: true,
     type: String,
     custom: function () {
-      if (this.siblingField('host').value && this.siblingField('host').value !== 'Select your video host from the dropdown') {
+      if (this.value && this.value !== "") {
         const host = this.siblingField('host').value.split(' (eg.')[0]  // <-- split out the 'example' at the end of host field text
         const prefixServer = videoHosts.find(e => e.host === host).prefix
         const prefixClient = this.value.slice(0, prefixServer.length)
@@ -493,27 +500,30 @@ const EventsSchema = new SimpleSchema({
     },
     uniforms: {
       label: null
-    },
-    defaultValue: labels.video.address
+    }
   },
   'video.link3': {
     type: Object,
     optional: true,
   },
   'video.link3.host': {
+    optional: true,
     type: String,
-    // optional: true,
-    allowedValues: videoHosts.map((e) => `${e.host} (eg. ${e.prefix}<VIDEO_ID>)`),
+    defaultValue: labels.video.host,
     uniforms: {
       customType: 'select',
-      label: null
-    },
-    defaultValue: labels.video.host
+      label: null,
+      allowedValues: videoHosts.map((e) => `${e.host} (eg. ${e.prefix}<VIDEO_ID>)`),
+      selectOptions: {
+        url: true
+      },
+    }
   },
   'video.link3.address': {
+    optional: true,
     type: String,
     custom: function () {
-      if (this.siblingField('host').value && this.siblingField('host').value !== 'Select your video host from the dropdown') {
+      if (this.value && this.value !== "") {
         const host = this.siblingField('host').value.split(' (eg.')[0]  // <-- split out the 'example' at the end of host field text
         const prefixServer = videoHosts.find(e => e.host === host).prefix
         const prefixClient = this.value.slice(0, prefixServer.length)
@@ -522,8 +532,7 @@ const EventsSchema = new SimpleSchema({
     },
     uniforms: {
       label: null
-    },
-    defaultValue: labels.video.address
+    }
   },
   'createdAt': {
     type: Date,

--- a/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
@@ -25,6 +25,7 @@ class SecondStep extends Component {
     
     const RadioButton = this.RadioButton
     const VideoEntry = this.VideoEntry
+    const VideoButtons = this.VideoButtons
 
     let { openEndDate, videoLinksAdded } = this.state
     const {
@@ -105,7 +106,10 @@ class SecondStep extends Component {
           type='radio'
         />
         {repeat && <Recurring form={form} />}
+
+        {/* Additional text description & attendee limit */}
         <AutoField className='pageDetails' name='description' />
+        <AutoField className='pageDetails' name='engagement.limit' />
 
         {/* Add video link(s) */}
         <CustomInput
@@ -117,32 +121,14 @@ class SecondStep extends Component {
           checked={videoLinksAdded > 0}
           onClick={this.toggleLinks}
         />
-          {videoLinksAdded > 0 && (
-            <div className='videoButtons'>
-              <Button
-                outline
-                color='secondary'
-                className='addLink'
-                onClick={this.addLink}
-                disabled={videoLinksAdded > 2}
-              >
-                Add Another Link
-              </Button>
-              <Button
-                outline
-                color='secondary'
-                className='removeLink'
-                onClick={this.removeLink}
-              >
-                Remove Last Link
-              </Button>
-            </div>
-          )}
         {videoLinksAdded > 0 && <VideoEntry id={1} form={form} />}
         {videoLinksAdded > 1 && <VideoEntry id={2} form={form} />}
         {videoLinksAdded > 2 && <VideoEntry id={3} form={form} />}
-
-        <AutoField className='pageDetails' name='engagement.limit' />
+        {videoLinksAdded > 0 && <VideoButtons
+          videoLinksAdded={videoLinksAdded}
+          addLink={this.addLink}
+          removeLink={this.removeLink}
+        />}
       </div>
     )
   }
@@ -169,7 +155,7 @@ class SecondStep extends Component {
     this.setState({ openEndDate: false })
   }
 
-  // DESCRIPTION: Node fragment that point to VideoLink component
+  // DESC: Node fragment that point to VideoLink component
   // This includes entry fields for hostname and url
   // Also includes error that displays when url is incorrect on submit
   VideoEntry = ({ id, form }) => (
@@ -184,6 +170,29 @@ class SecondStep extends Component {
         errorMessage='Invalid URL, please ensure it conforms to the example shown'
       />
     </Fragment>
+  )
+
+  // DESC: Node fragment to add/remove video buttons
+  VideoButtons = ({ videoLinksAdded, addLink, removeLink }) => (
+    <div className='videoButtons'>
+      <Button
+        outline
+        color='secondary'
+        className='addLink'
+        onClick={addLink}
+        disabled={videoLinksAdded > 2}
+      >
+        Add Another Link
+      </Button>
+      <Button
+        outline
+        color='secondary'
+        className='removeLink'
+        onClick={removeLink}
+      >
+        Remove Last Link
+      </Button>
+    </div>
   )
 
   RadioButton = ({ label, id, value, type }) => (

--- a/imports/client/ui/pages/NewEvent/FormWizard/VideoLink/index.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/VideoLink/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { FormGroup, Input, Label } from 'reactstrap'
 import AutoField from '/imports/client/utils/uniforms-custom/AutoField'
 import { videoHosts } from '/imports/both/collections/events/helpers/index.js'
+import labels from '/imports/both/i18n/en/new-event-modal.json'
 import './styles.scss'
 
 class VideoLink extends Component {
@@ -26,7 +27,7 @@ class VideoLink extends Component {
         <AutoField
           className="videoAddress"
           name={`${this.props.name}.address`}
-          // placeholder={this.fetchVideoURL(1, this.props.form)} <-- not updating dynamically... force re-render on host select?
+          placeholder={labels.video.address}
         />
       </div>
     )

--- a/imports/client/ui/pages/NewEvent/FormWizard/VideoLink/styles.scss
+++ b/imports/client/ui/pages/NewEvent/FormWizard/VideoLink/styles.scss
@@ -15,5 +15,9 @@
     input {
       font-size: 12px;
     }
+    input::placeholder {
+      // color: gray
+      color: rgba(128,128,128, 0.7);
+    }
   }
 }

--- a/imports/client/ui/pages/NewEvent/styles.scss
+++ b/imports/client/ui/pages/NewEvent/styles.scss
@@ -238,7 +238,7 @@
   display: flex;
   justify-content: flex-start;
   position: relative;
-  padding: 12px 0px;
+  padding: 0px 0px;
 
     button {
       margin: 0px 5px;

--- a/imports/client/utils/uniforms-custom/SelectField.js
+++ b/imports/client/utils/uniforms-custom/SelectField.js
@@ -32,17 +32,30 @@ class Select_ extends Component {
 
     const {
       googleMaps,
-      multi
+      multi,
+      url
     } = selectOptions
 
     const className = 'select-field ' + (error ? 'error' : '')
 
     let value_ = this.getValues(value)
-
+  
     return (
       <FormGroup className={className}>
         <Label>{label}</Label>
-        {!googleMaps ? (
+        {/* Displays a different kind of dropdown depending on the url and googleMaps props */}
+        {url && (
+          <Select
+            value={value_}
+            options={options}
+            isMulti={multi}
+            isSearchable={false}
+            onChange={this.handleChange}
+            placeholder={''}
+            menuPlacement='top'
+          />
+        )}
+        {!url && !googleMaps && (
           <Select
             value={value_}
             options={options}
@@ -50,8 +63,10 @@ class Select_ extends Component {
             onChange={this.handleChange}
             placeholder={''}
             isSearchable={false}
+            menuPlacement='auto'
           />
-        ) : (
+        )}
+        {googleMaps && (
           <PlacesSearchBox
             onSelect={value => this.handlePlacesChange(value)}
             address={value ? value.name : null}


### PR DESCRIPTION
Managed to incorporate the bulk of the changes we discussed, in one way or another:

1 - **Difficulty scrolling down list of video hosts when having to click via a desktop mouse.**
This one was a bit harder than I had anticipated: the scrollbar does not appear because the react form prefers to expand the entire modal rather than add a scrollbar to the submenu. **Workaround**: I've moved the video links section to the very end of the form (below attendee limit), and made it so that the menu opens up UP instead of DOWN. That way you will always have enough room on the screen to see every choice (except for smaller mobiles, but they can thumb-scroll I guess)

2 - **Moving buttons to below the links** done

3 - **Error in video links submission sometimes propagates to description input box** After moving things around (the description is now in a separate section of the form) I'm not able to replicate the error any more, though I'm still not 100% sure why it was happening, so if you see this again let me know.

4 - **Grey placeholder text for entering URLs** done. As a side note, while testing this I realised it gets very annoying for users who open up a second or third link, then close it again to later get thrown an error for trying to submit an "empty" link (when the box is not even visible to them any more). **TLTR:** So I've also changed the validation so that the form will not stop them from submitting an empty link however it will throw an error if they type in a link that is incorrect.

Any questions let me know.