### PR TITLE
DCS Balloons/Docus sidebar icons can now be added anywhere on site (master)

### DIFF
--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -133,6 +133,9 @@ class App extends Component {
           const pageId = window.location.pathname.substring(prefix.length);
           const tag = "dcs-" + pageId.substring(0, 12).toLowerCase() + "-" + b;
           dcs.gotoTag(tag);
+        } else if (window.location.pathname.startsWith('/about')) {
+          const tag = "dcs-about-" + b
+          dcs.gotoTag(tag)
         }
       } else if (d) {
         dcs.gotoPath(d);

--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -134,12 +134,9 @@ class App extends Component {
           const tag = "dcs-" + pageId.substring(0, 12).toLowerCase() + "-" + b;
           dcs.gotoTag(tag);
         } else if (window.location.pathname.startsWith('/')) {
-          console.log('firing else statement - starting string /')
           const pathname = window.location.pathname
-          console.log(pathname)
           const endIndex = pathname.search('\\?') > -1 ? pathname.search('\\?') : pathname.length
           const tagLocation = pathname.slice(pathname.search('/') + 1, endIndex)
-          console.log('target tag: ' + tagLocation)
           const tag = "dcs-" + tagLocation + "-" + b
           dcs.gotoTag(tag)
         }

--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -189,7 +189,10 @@ class App extends Component {
                 <Route exact path="/partners" component={Partners} />
                 <Route exact path="/whitepaper" component={Whitepaper} />
                 <Route exact path="/faq" component={Faq} />
-                <Route exact path="/about" component={About} />
+                <Route
+                  exact
+                  path="/about"
+                  render={props => <About {...props} {...dcsProps}/>} />
                 <Route path="/map" component={Map_} />
                 <Route path="*" render={this.renderNewEvent} />
                 <Route exact path="/thank-you" component={CongratsModal} />

--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -133,8 +133,14 @@ class App extends Component {
           const pageId = window.location.pathname.substring(prefix.length);
           const tag = "dcs-" + pageId.substring(0, 12).toLowerCase() + "-" + b;
           dcs.gotoTag(tag);
-        } else if (window.location.pathname.startsWith('/about')) {
-          const tag = "dcs-about-" + b
+        } else if (window.location.pathname.startsWith('/')) {
+          console.log('firing else statement - starting string /')
+          const pathname = window.location.pathname
+          console.log(pathname)
+          const endIndex = pathname.search('\\?') > -1 ? pathname.search('\\?') : pathname.length
+          const tagLocation = pathname.slice(pathname.search('/') + 1, endIndex)
+          console.log('target tag: ' + tagLocation)
+          const tag = "dcs-" + tagLocation + "-" + b
           dcs.gotoTag(tag)
         }
       } else if (d) {
@@ -192,10 +198,7 @@ class App extends Component {
                 <Route exact path="/partners" component={Partners} />
                 <Route exact path="/whitepaper" component={Whitepaper} />
                 <Route exact path="/faq" component={Faq} />
-                <Route
-                  exact
-                  path="/about"
-                  render={props => <About {...props} {...dcsProps}/>} />
+                <Route exact path="/about" component={About} />
                 <Route path="/map" component={Map_} />
                 <Route path="*" render={this.renderNewEvent} />
                 <Route exact path="/thank-you" component={CongratsModal} />

--- a/imports/client/ui/components/DCSBalloon/index.js
+++ b/imports/client/ui/components/DCSBalloon/index.js
@@ -1,0 +1,142 @@
+import React, { Component, Fragment } from 'react'
+import qs from 'query-string'
+import history from "../../../utils/history";
+import { dcs } from "../../../utils/dcs-master";
+
+
+/*********************/
+/*
+  Render Docuss Balloon that redirects to dedicated forum page
+*/
+/*********************/
+
+class DCSBalloon extends Component {
+  
+  constructor(props) {
+    super()
+    this.state = {
+      selBalloonId: null,
+      badges: null
+    }
+  }
+  
+  dcsClick(balloonId, e) {
+    dcsClickApp(balloonId)
+    e.stopPropagation() // Required for deselection
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    // DOCUSS
+    // Update selBalloonId here, so that we catch url changes triggered
+    // in other components
+    const { b } = qs.parse(window.location.search)
+    if (this.state.selBalloonId !== b) {
+      this.setState({ selBalloonId: b })
+    }
+
+    // DOCUSS
+    // Add badges (color circles with topic count)
+    if (!this.state.badges && this.props.dcsTags) {
+      const prefix = `dcs-${this.state.id.substring(0, 12).toLowerCase()}-`
+      const badges = {}
+      this.props.dcsTags.forEach(tag => {
+        if (tag.id.startsWith(prefix)) {
+          const balloonId = tag.id.substring(17)
+          badges[balloonId] = tag.count
+        }
+      })
+      this.setState({ badges })
+    }
+  }
+    
+  render() {
+
+    const {
+      title,
+      subtitle,
+      balloonId,
+      display
+    } = this.props
+
+    const badgeCount = (this.state.badges && this.state.badges[balloonId]) || 0
+    const badgeHtml = (
+      <span
+        className="dcs-badge"
+        title={`This section has ${badgeCount} topic(s)`}
+      >
+        {badgeCount}
+      </span>
+    )
+
+    const titleClass =
+      balloonId === this.state.selBalloonId ? 'dcs-selected' : ''
+
+    return (
+      <div
+        style={{ margin: '20px 0', cursor: 'pointer', display: display, padding: '0px 10px' }}
+        onClick={e => this.dcsClick(balloonId, e)}
+      >
+        <b className={titleClass}>{title}</b>&nbsp;
+
+          <span className="dcs-icons">
+          <img src={`/images/dcs-balloon-${balloonId}.png`} />
+        </span>
+        {badgeCount ? badgeHtml : ''}
+        <div>
+          <small style={{ marginLeft: '5px', marginRight: '5px', fontSize: '60%' }}>
+            {subtitle}
+          </small>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default DCSBalloon
+
+// NOTE: BELOW IS COPIED DIRECTLY FROM APP.JS (function named dcsClick) - NEED TO REFACTOR TO PREVENT DUPLICATION
+
+function dcsClickApp(balloonId) {
+  if (balloonId) {
+    if (balloonId.length > 3 || balloonId.toLowerCase() !== balloonId) {
+      throw new Error(`Invalid balloonId "${balloonId}"`);
+    }
+    changeHistory({
+      params: { r: "1", b: balloonId, t: null, d: null },
+      push: true
+    });
+  } else {
+    changeHistory({
+      params: { r: null, b: null, t: null, d: null },
+      push: true
+    });
+  }
+}
+
+// NOTE: BELOW IS COPIED DIRECTLY FROM APP.JS - NEED TO REFACTOR TO PREVENT DUPLICATION
+
+// A falsy pathname means the pathname won't be changed
+// An undefined query params means the query param won't be changed
+// A null query params means the query param will be removed
+function changeHistory({ pathname = null, params, push }) {
+  const p = Object.assign(params);
+  Object.keys(p).forEach(key => p[key] === undefined && delete p[key]);
+  const s = qs.parse(window.location.search);
+  Object.assign(s, p);
+  Object.keys(s).forEach(key => s[key] === null && delete s[key]);
+  const search = qs.stringify(s);
+  //############################################################################
+  // TERRIBLE WORKAROUND FOR ISSUE https://github.com/focallocal/fl-maps/issues/742
+  if (pathname && pathname !== location.pathname) {
+    console.log("##########", pathname + "?" + search);
+    location.href = pathname + "?" + search;
+    return;
+  }
+  //############################################################################
+  pathname = pathname || window.location.pathname;
+  if (push) {
+    history.push({ pathname, search });
+  } else {
+    history.replace({ pathname, search });
+  }
+}

--- a/imports/client/ui/pages/About/index.js
+++ b/imports/client/ui/pages/About/index.js
@@ -3,19 +3,10 @@ import TopImageSection from './TopImageSection'
 import FirstSection from './FirstSection'
 import SecondSection from './SecondSection'
 import AboutSection from '../Home/SecondSection'
+import i18n from '/imports/both/i18n/en'
 import './styles.scss'
 
 class About extends Component {
-  constructor(props) {
-    super()
-    this.state = {
-      data: window.cachedDataForPage,
-      id: props.match.params.id,
-      loaded: false,
-      badges: null
-    }
-  }
-
   componentDidMount () {
     window.__setDocumentTitle('About')
   }

--- a/imports/client/ui/pages/About/index.js
+++ b/imports/client/ui/pages/About/index.js
@@ -3,7 +3,6 @@ import TopImageSection from './TopImageSection'
 import FirstSection from './FirstSection'
 import SecondSection from './SecondSection'
 import AboutSection from '../Home/SecondSection'
-import i18n from '/imports/both/i18n/en'
 import './styles.scss'
 
 class About extends Component {
@@ -17,7 +16,6 @@ class About extends Component {
     }
   }
 
-
   componentDidMount () {
     window.__setDocumentTitle('About')
   }
@@ -27,7 +25,6 @@ class About extends Component {
     return (
       <div id='about'>
         <h2>About Us</h2>
-        {this.dcsHeading(i18n.Map.eventInfo.wall.title, i18n.Map.eventInfo.wall.subtitle, 'wal')}
         <div className='header-divider' />
         <TopImageSection />
         <AboutSection button= {false} />
@@ -36,45 +33,6 @@ class About extends Component {
       </div>
     )
   }
-
-  // DOCUSS
-  dcsHeading(title, subtitle, balloonId) {
-    const badgeCount = (this.state.badges && this.state.badges[balloonId]) || 0
-    const badgeHtml = (
-      <span
-        className="dcs-badge"
-        title={`This section has ${badgeCount} topic(s)`}
-      >
-        {badgeCount}
-      </span>
-    )
-    const titleClass =
-      balloonId === this.state.selBalloonId ? 'dcs-selected' : ''
-    return (
-      <div
-        style={{ margin: '20px 0', cursor: 'pointer' }}
-        onClick={e => this.dcsClick(balloonId, e)}
-      >
-        <b className={titleClass}>{title}</b>&nbsp;
-
-        <span className="dcs-icons">
-          <img src={`/images/dcs-balloon-${balloonId}.png`} />
-        </span>
-        {badgeCount ? badgeHtml : ''}
-        <div>
-          <small style={{ marginLeft: '5px', marginRight: '5px', fontSize: '60%' }}>
-            {subtitle}
-          </small>
-        </div>
-      </div>
-    )
-  }
-
-  dcsClick(balloonId, e) {
-    this.props.dcsClick(balloonId)
-    e.stopPropagation() // Required for deselection
-  }
-
 }
 
 export default About

--- a/imports/client/ui/pages/About/index.js
+++ b/imports/client/ui/pages/About/index.js
@@ -7,6 +7,17 @@ import i18n from '/imports/both/i18n/en'
 import './styles.scss'
 
 class About extends Component {
+  constructor(props) {
+    super()
+    this.state = {
+      data: window.cachedDataForPage,
+      id: props.match.params.id,
+      loaded: false,
+      badges: null
+    }
+  }
+
+
   componentDidMount () {
     window.__setDocumentTitle('About')
   }
@@ -16,6 +27,7 @@ class About extends Component {
     return (
       <div id='about'>
         <h2>About Us</h2>
+        {this.dcsHeading(i18n.Map.eventInfo.wall.title, i18n.Map.eventInfo.wall.subtitle, 'wal')}
         <div className='header-divider' />
         <TopImageSection />
         <AboutSection button= {false} />
@@ -24,6 +36,45 @@ class About extends Component {
       </div>
     )
   }
+
+  // DOCUSS
+  dcsHeading(title, subtitle, balloonId) {
+    const badgeCount = (this.state.badges && this.state.badges[balloonId]) || 0
+    const badgeHtml = (
+      <span
+        className="dcs-badge"
+        title={`This section has ${badgeCount} topic(s)`}
+      >
+        {badgeCount}
+      </span>
+    )
+    const titleClass =
+      balloonId === this.state.selBalloonId ? 'dcs-selected' : ''
+    return (
+      <div
+        style={{ margin: '20px 0', cursor: 'pointer' }}
+        onClick={e => this.dcsClick(balloonId, e)}
+      >
+        <b className={titleClass}>{title}</b>&nbsp;
+
+        <span className="dcs-icons">
+          <img src={`/images/dcs-balloon-${balloonId}.png`} />
+        </span>
+        {badgeCount ? badgeHtml : ''}
+        <div>
+          <small style={{ marginLeft: '5px', marginRight: '5px', fontSize: '60%' }}>
+            {subtitle}
+          </small>
+        </div>
+      </div>
+    )
+  }
+
+  dcsClick(balloonId, e) {
+    this.props.dcsClick(balloonId)
+    e.stopPropagation() // Required for deselection
+  }
+
 }
 
 export default About

--- a/imports/client/ui/pages/Faq/Content.js
+++ b/imports/client/ui/pages/Faq/Content.js
@@ -2,13 +2,17 @@
 import React from "react";
 import { Container, Row, Col } from "reactstrap";
 import i18n from "../../../../both/i18n/en";
+import DCSBalloon from '/imports/client/ui/components/DCSBalloon/index.js'
 
 const Content = () => {
   return (
     <React.Fragment>
       <Container className="mt-5">
         <h1>Looking for answers?</h1>
-        <p>Take a look at frequently asked questions</p>
+        <p>
+          Take a look at frequently asked questions
+          <DCSBalloon title="Test Title" subtitle="Test Subtitle" balloonId="bal" display="inline" />
+        </p>
       </Container>
       {i18n.Faq.faq.map((item, index) => {
         return (


### PR DESCRIPTION
Relates to [this issue](https://trello.com/c/zvu6y3GJ/550-team-challenge-docus-sidebar-icons-can-be-added-anywhere-in-the-site)

**Note** in order to minimize code repetition, I've updated how the balloons are rendered in other parts of the site .

 _Before_: rendered via a function that needs to be defined within the same component where you want to add the balloon, and which depends on a handful of other functions, some of which were also being defined locally and some passed down as component props from app.js:

`{this.dcsHeading(title, subtitle, balloonCode)}`

 _After_: the DCS balloon is now its own React component with most of the logic defined internally (so it can be added anywhere on the site without having to include additional functions/logic). On the page you want to add a baloon you would include the following 2 lines of code, and the resulting balloon is treated like a regular html tag (there is a new field called 'display' to specify if you want the balloon to behave as an inline or a block tag):
```
import DCSBalloon from '/imports/client/ui/components/DCSBalloon/index.js'

<DCSBalloon title={title} subtitle={subtitle} balloonId={balloonCode} display={inline or block} />
```
I've added an example balloon on the FAQ page - I've tagged this with the balloon code "bal", so on docuss it will direct you to the page "Restricted https://discuss.focallocal.org/tags/dcs-faq-bal". The two parts that will change depending on how/where you render the balloon are "faq" (taken from the page location) and "bal" (taken from the balloon code you give the component as a prop)

Any questions let me know.

PS: I haven't refactored the code on the maps pages yet (where the balloons were already working). At the moment the balloons there are rendered the original way, if people are happy to change it here too (and assuming there are no bugs with the React way) I can change it here too in a later update to make it the same process across the whole site.