### PR TITLE
Enable multiple balloons of the same type (master)

### DIFF
--- a/imports/client/ui/components/DCSBalloon/index.js
+++ b/imports/client/ui/components/DCSBalloon/index.js
@@ -79,7 +79,7 @@ class DCSBalloon extends Component {
         <b className={titleClass}>{title}</b>&nbsp;
 
           <span className="dcs-icons">
-          <img src={`/images/dcs-balloon-${balloonId}.png`} />
+          <img src={`/images/dcs-balloon-${balloonId.replace(/[0-9]/g, '')}.png`} />
         </span>
         {badgeCount ? badgeHtml : ''}
         <div>
@@ -98,7 +98,7 @@ export default DCSBalloon
 
 function dcsClickApp(balloonId) {
   if (balloonId) {
-    if (balloonId.length > 3 || balloonId.toLowerCase() !== balloonId) {
+    if (balloonId.replace(/[0-9]/g, '').length > 3 || balloonId.toLowerCase() !== balloonId) {
       throw new Error(`Invalid balloonId "${balloonId}"`);
     }
     changeHistory({

--- a/imports/client/ui/pages/Faq/Content.js
+++ b/imports/client/ui/pages/Faq/Content.js
@@ -11,7 +11,7 @@ const Content = () => {
         <h1>Looking for answers?</h1>
         <p>
           Take a look at frequently asked questions
-          <DCSBalloon title="Test Title" subtitle="Test Subtitle" balloonId="bal" display="inline" />
+          <DCSBalloon title="Test Title" subtitle="Test Subtitle" balloonId="bal1" display="inline" />
         </p>
       </Container>
       {i18n.Faq.faq.map((item, index) => {


### PR DESCRIPTION
BEFORE: Each DCSBalloon was identified by its code (e.g. 'pho' = photos), all balloons on the same page of the same type lead to the same landing site on the forum (e.g. all photo balloons on a particular page lead to the same landing site)

AFTER: you can now add a numeric multiplier to the balloon code (e.g. 'pho123'), this will modify the landing page accordingly. The balloon's icon will be the same across all of the same type (e.g. same icon for pho1 and pho5)

NOTE: adding a non-numeric character to the balloon code (e.g. 'phoxyz') will throw an error.
