### PR TITLE
Balloons now display created forum topics for their respective landing page (master)

### DIFF
--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -191,18 +191,15 @@ class App extends Component {
 
               <ScrollToTop>
                 <Route exact path="/(home)?" component={Home} />
-                <Route exact path="/team" component={Team} />
-                <Route exact path="/partners" component={Partners} />
-                <Route exact path="/whitepaper" component={Whitepaper} />
-                <Route exact path="/faq" component={Faq} />
-                <Route exact path="/about" component={About} />
+                <Route exact path="/team" render={props => <Team {...props} {...dcsProps} />} />
+                <Route exact path="/partners" render={props => <Partners {...props} {...dcsProps} />} />
+                <Route exact path="/whitepaper" render={props => <Whitepaper {...props} {...dcsProps} />} />
+                <Route exact path="/faq" render={props => <Faq {...props} {...dcsProps} />}/>
+                <Route exact path="/about" render={props => <About {...props} {...dcsProps} />}/>
                 <Route path="/map" component={Map_} />
                 <Route path="*" render={this.renderNewEvent} />
                 <Route exact path="/thank-you" component={CongratsModal} />
-                <Route
-                  exact
-                  path="/page/:id"
-                  render={props => <Page {...props} {...dcsProps} />}
+                <Route exact path="/page/:id" render={props => <Page {...props} {...dcsProps} />}
                 />
 
                 <Authentication />

--- a/imports/client/ui/components/DCSBalloon/index.js
+++ b/imports/client/ui/components/DCSBalloon/index.js
@@ -1,7 +1,8 @@
 import React, { Component, Fragment } from 'react'
 import qs from 'query-string'
-import history from "../../../utils/history";
-import { dcs } from "../../../utils/dcs-master";
+import history from "../../../utils/history"
+import { dcs } from "../../../utils/dcs-master"
+import './style.scss'
 
 
 /*********************/
@@ -16,7 +17,7 @@ class DCSBalloon extends Component {
     super()
     this.state = {
       selBalloonId: null,
-      badges: null
+      topicCount: null
     }
   }
   
@@ -35,22 +36,25 @@ class DCSBalloon extends Component {
     }
 
     // DOCUSS
-    // Add badges (color circles with topic count)
-    if (!this.state.badges && this.props.dcsTags) {
-      const prefix = `dcs-${this.state.id.substring(0, 12).toLowerCase()}-`
-      const badges = {}
-      this.props.dcsTags.forEach(tag => {
-        if (tag.id.startsWith(prefix)) {
-          const balloonId = tag.id.substring(17)
-          badges[balloonId] = tag.count
-        }
-      })
-      this.setState({ badges })
+    // Add topic count to component state
+    if (prevProps.dcsTags !== this.props.dcsTags) {
+      const pathname = window.location.pathname
+      const endIndex = pathname.search('\\?') > -1 ? pathname.search('\\?') : pathname.length
+      const tagLocation = pathname.slice(pathname.search('/') + 1, endIndex)
+      const prefix = `dcs-${tagLocation}-${this.props.balloonId}`
+      console.log('prefix: ' + prefix)
+      console.log(prefix)
+      const tag = this.props.dcsTags.find(tag => tag.id.startsWith(prefix))
+      console.log('tag: ')
+      console.log(tag)
+      const count = tag? tag.count : 0
+      this.setState({ topicCount: count })
     }
   }
     
   render() {
-
+    console.log('props: ')
+    console.log(this.props)
     const {
       title,
       subtitle,
@@ -58,13 +62,13 @@ class DCSBalloon extends Component {
       display
     } = this.props
 
-    const badgeCount = (this.state.badges && this.state.badges[balloonId]) || 0
+    const topicCount = this.state.topicCount || 0
     const badgeHtml = (
       <span
         className="dcs-badge"
-        title={`This section has ${badgeCount} topic(s)`}
+        title={`This section has ${topicCount} topic(s)`}
       >
-        {badgeCount}
+        {topicCount}
       </span>
     )
 
@@ -81,7 +85,7 @@ class DCSBalloon extends Component {
           <span className="dcs-icons">
           <img src={`/images/dcs-balloon-${balloonId.replace(/[0-9]/g, '')}.png`} />
         </span>
-        {badgeCount ? badgeHtml : ''}
+        {topicCount ? badgeHtml : ''}
         <div>
           <small style={{ marginLeft: '5px', marginRight: '5px', fontSize: '60%' }}>
             {subtitle}

--- a/imports/client/ui/components/DCSBalloon/style.scss
+++ b/imports/client/ui/components/DCSBalloon/style.scss
@@ -1,0 +1,18 @@
+.dcs-badge {
+      display: inline-block;
+      border-radius: 10px;
+      padding: 3px 5px;
+      min-width: 8px;
+      vertical-align: middle;
+      margin-left: 5px;
+      color: #fff;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 11px;
+      text-align: center;
+      background-color: #bdbdbd;
+      /* Reset */
+      line-height: 1;
+      font-weight: normal;
+      white-space: nowrap;
+      text-indent: 0;
+    }

--- a/imports/client/ui/pages/Faq/Content.js
+++ b/imports/client/ui/pages/Faq/Content.js
@@ -4,14 +4,14 @@ import { Container, Row, Col } from "reactstrap";
 import i18n from "../../../../both/i18n/en";
 import DCSBalloon from '/imports/client/ui/components/DCSBalloon/index.js'
 
-const Content = () => {
+const Content = (props) => {
   return (
     <React.Fragment>
       <Container className="mt-5">
         <h1>Looking for answers?</h1>
         <p>
           Take a look at frequently asked questions
-          <DCSBalloon title="Test Title" subtitle="Test Subtitle" balloonId="bal1" display="inline" />
+          <DCSBalloon title="Test Title" subtitle="Test Subtitle" balloonId="bal1" display="inline" dcsTags={props.dcsTags} />
         </p>
       </Container>
       {i18n.Faq.faq.map((item, index) => {

--- a/imports/client/ui/pages/Faq/index.js
+++ b/imports/client/ui/pages/Faq/index.js
@@ -2,8 +2,8 @@
 import React from "react";
 import Content from "./Content";
 
-const Index = () => {
-  return <Content />;
+const Index = (props) => {
+  return <Content dcsTags={props.dcsTags}/>;
 };
 
 export default Index;

--- a/imports/client/ui/pages/WhitePaper/index.js
+++ b/imports/client/ui/pages/WhitePaper/index.js
@@ -15,13 +15,13 @@ md.set({
   linkify: true
 });
 var markdown = md.render("# Public Happiness Movement Whitepaper \n  \n**Foreword:**  \n  \as is possible in the Western World because d in the section, and cross-posted into the forum's voting section for community-wide visibility. One thread for arguments for, and one for arguments against the change.   \n  \nStage 3: \  \nUsers are all welcome to comment their argument in the threads for and against, the threads will be ordered by likes received so the strongest arguments float to the top.  \n  \nStage 4: \  \nAfter reading the topic users can vote on the topic 'for' or 'against' the change, if the 'for' topic receives more than 55% the change is agreed to be inducted offline will be required to post hashtags on social media of photos and videos taken at their activity as proof of work, which are tracked by our bot, linked to their account, and published in a list of pending tokens earned, making it simple for other users and bounty hunters to check if they think something suspicious is going on (the requirement for posting and hashtags is also fantastic opro mounted, so that viewers can tune in to our Youtube and watch clips of life travelling the world with a community in a bus/van fleet, and creating public happiness, from the perspective of a very happy dog.  \n  ");//"# Welcome to the 1st Draft"
-//console.log(markdown);
 
-
-const index = () => {
+const index = (props) => {
   return (
     <Container className="mt-5">
-     <div dangerouslySetInnerHTML={{__html: markdown}} />       
+      <div dangerouslySetInnerHTML={{__html: markdown}} />
+      <DCSBalloon title="Test Title" subtitle="Test Subtitle" balloonId="bal" display="inline" dcsTags={props.dcsTags} />     
+      <DCSBalloon title="Test Title" subtitle="Test Subtitle" balloonId="bal1" display="inline" dcsTags={props.dcsTags} />     
     </Container>
 
   );


### PR DESCRIPTION
Balloon component now takes an additional prop (dcsTags) which is data passed from docuss via app.js. Consequently app.js has been refactored to pass dcsTags to its children.. but if you need to add a balloon to it's 'grandchildren', you would need to refactor accordingly to pass dcsTags onto them as a prop then onto DCSBalloon. Have done this for the whitepaper page, and the first page of the FAQ.

Placeholder example added to whitepaper page (Screenshot):
- first balloon points to code 'bal' which has 1 topic posted in the forum
- second and third balloons point to 'bal1' and 'bal2' respectively, will update once topics are posted onto their landing pages

![Screenshot from 2019-03-26 17-30-23](https://user-images.githubusercontent.com/26905074/55019618-2948ef80-4fed-11e9-8e10-b24dd1996587.png)
