### PR TITLE
Update map to display all visible events on zoom out (master)

### DIFF
--- a/server/methods/events/getEvents.js
+++ b/server/methods/events/getEvents.js
@@ -15,6 +15,7 @@ const getEvents = new ValidatedMethod({
       type: Object,
       optional: true
     },
+    distance: Number,
     'location.lat': Number,
     'location.lng': Number,
     count: {

--- a/server/methods/events/getFutureEvents.js
+++ b/server/methods/events/getFutureEvents.js
@@ -15,6 +15,7 @@ const getFutureEvents = new ValidatedMethod({
       type: Object,
       optional: true
     },
+    distance: Number,
     'location.lat': Number,
     'location.lng': Number,
     count: {


### PR DESCRIPTION
Relates to [this issue on Trello](https://trello.com/c/I8EyfawY/437-both-key-task-urgent-pins-arent-showing-on-the-map-at-all-except-for-the-area-you-search), or [this on GitHub](https://github.com/focallocal/fl-maps/issues/820)

Problem: getEvents methods were set to return events limited to 100km from centre of google map
Resolution: will now return events within 100km, OR within the visible screen radius (whichever is greater).