### PR TITLE
Admin roles page

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -27,3 +27,4 @@ accounts-twitter
 aldeed:collection2@3.0.0
 mdg:validated-method
 ddp-rate-limiter
+alanning:roles

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -4,6 +4,7 @@ accounts-google@1.3.1
 accounts-oauth@1.1.15
 accounts-password@1.5.1
 accounts-twitter@1.4.1
+alanning:roles@1.2.16
 aldeed:collection2@3.0.0
 allow-deny@1.1.0
 ardatan:webpack@0.0.5_7

--- a/imports/both/i18n/en/menu.json
+++ b/imports/both/i18n/en/menu.json
@@ -17,7 +17,17 @@
         "title": "Sign up",
         "route": "/sign-up"
       }
-    ]
+    ],
+      "Admin": [
+      {
+        "title": "Sign out",
+        "route": "/sign-out"
+      },
+      {
+        "title": "Admin",
+        "route": "/admin"
+      }
+      ]
   },
   "leftLinks": [
     {

--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -29,6 +29,7 @@ import Page from "./pages/Page";
 
 // Components
 import ScrollToTop from "./components/ScrollToTop";
+import Admin from "./pages/Admin/index"
 
 class App extends Component {
   constructor() {
@@ -197,6 +198,7 @@ class App extends Component {
                 <Route exact path="/faq" render={props => <Faq {...props} {...dcsProps} />}/>
                 <Route exact path="/about" render={props => <About {...props} {...dcsProps} />}/>
                 <Route path="/map" component={Map_} />
+                <Route exact path="/admin" render={props => <Admin {...props}/>} /> 
                 <Route path="*" render={this.renderNewEvent} />
                 <Route exact path="/thank-you" component={CongratsModal} />
                 <Route exact path="/page/:id" render={props => <Page {...props} {...dcsProps} />}

--- a/imports/client/ui/includes/MainMenu/UserItem/index.js
+++ b/imports/client/ui/includes/MainMenu/UserItem/index.js
@@ -2,8 +2,18 @@ import React from "react";
 import DropDownItem from "../DropDownItem";
 
 import i18n from "/imports/both/i18n/en";
-
+//import admin from './../../../../utils/adminControl';
 const UserItem = ({ user }) => {
+  // add check for specific email for initial admin setup
+ 
+  //console.log('user', user._id);
+
+  // if (user.admin === true) {
+  //   userStatus = 'Admin'
+  // }
+  // else {
+  //   userStatus = user ? "loggedIn" : "loggedOut";
+  // }
   const userStatus = user ? "loggedIn" : "loggedOut";
   const item = {
     title: "",

--- a/imports/client/ui/includes/MainMenu/UserItem/index.js
+++ b/imports/client/ui/includes/MainMenu/UserItem/index.js
@@ -1,20 +1,21 @@
-import React from "react";
-import DropDownItem from "../DropDownItem";
-
-import i18n from "/imports/both/i18n/en";
-//import admin from './../../../../utils/adminControl';
+import React from "react"
+import DropDownItem from "../DropDownItem"
+import i18n from "/imports/both/i18n/en"
+import { Roles } from 'meteor/alanning:roles'
+import { permissions} from './../../../pages/Admin/RolesPermissions/index'
 const UserItem = ({ user }) => {
-  // add check for specific email for initial admin setup
- 
-  //console.log('user', user._id);
-
-  // if (user.admin === true) {
-  //   userStatus = 'Admin'
-  // }
-  // else {
-  //   userStatus = user ? "loggedIn" : "loggedOut";
-  // }
-  const userStatus = user ? "loggedIn" : "loggedOut";
+  let userStatus;
+  let isShowAdminLink = false;
+  if (user){
+    isShowAdminLink = Roles.userIsInRole(user._id, permissions['adminPage'])
+    console.log('isShowAdminLink', isShowAdminLink);
+  }
+  if (isShowAdminLink) {
+    userStatus = 'Admin'
+  }
+  else {
+    userStatus = user ? "loggedIn" : "loggedOut";
+  }
   const item = {
     title: "",
     icon: "fas fa-user-circle user",

--- a/imports/client/ui/includes/MainMenu/index.js
+++ b/imports/client/ui/includes/MainMenu/index.js
@@ -16,29 +16,6 @@ class MainMenu extends Component {
     sidebarOpen: false
   };
 
-  componentDidMount() {
- 
-
-  }
-
-  componentDidUpdate(prevProps, prevState){
-    // if (prevProps.user !== this.props.user && prevProps.user._id != this.props.user._id){
-    //   const { user } = this.props;
-
-    //   console.log('userMenu', user);
-    //   if (user) {
-    //     Meteor.call('Admin.createAdmin', {id: user._id}, (err, res) => {
-    //       if (!err) {
-    //         throw new Meteor.Error('could not find user...')
-    //       }
-
-  
-    //     })
-
-    //   }
-    // }
-  }
-
   render() {
     const { sidebarOpen } = this.state;
     const { user } = this.props;

--- a/imports/client/ui/includes/MainMenu/index.js
+++ b/imports/client/ui/includes/MainMenu/index.js
@@ -10,21 +10,41 @@ import UserItem from "./UserItem";
 import Logo from "./Logo";
 import i18n from "/imports/both/i18n/en";
 import "./styles.scss";
-import { createAdmin} from "./../../../utils/adminControl";
+
 class MainMenu extends Component {
   state = {
     sidebarOpen: false
   };
 
+  componentDidMount() {
+ 
+
+  }
+
+  componentDidUpdate(prevProps, prevState){
+    // if (prevProps.user !== this.props.user && prevProps.user._id != this.props.user._id){
+    //   const { user } = this.props;
+
+    //   console.log('userMenu', user);
+    //   if (user) {
+    //     Meteor.call('Admin.createAdmin', {id: user._id}, (err, res) => {
+    //       if (!err) {
+    //         throw new Meteor.Error('could not find user...')
+    //       }
+
+  
+    //     })
+
+    //   }
+    // }
+  }
+
   render() {
     const { sidebarOpen } = this.state;
     const { user } = this.props;
-
+    
     const { MainMenu } = i18n;
-    console.log('userMenu', user);
-    if (user){
-      createAdmin(user);
-    }
+
     
     return (
       <Fragment>

--- a/imports/client/ui/includes/MainMenu/index.js
+++ b/imports/client/ui/includes/MainMenu/index.js
@@ -10,7 +10,7 @@ import UserItem from "./UserItem";
 import Logo from "./Logo";
 import i18n from "/imports/both/i18n/en";
 import "./styles.scss";
-
+import { createAdmin} from "./../../../utils/adminControl";
 class MainMenu extends Component {
   state = {
     sidebarOpen: false
@@ -21,7 +21,11 @@ class MainMenu extends Component {
     const { user } = this.props;
 
     const { MainMenu } = i18n;
-
+    console.log('userMenu', user);
+    if (user){
+      createAdmin(user);
+    }
+    
     return (
       <Fragment>
         <Navbar id="main-menu" expand="md">

--- a/imports/client/ui/pages/Admin/AdminTable/index.js
+++ b/imports/client/ui/pages/Admin/AdminTable/index.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Link } from 'react-router-dom'
+import { Table, Col  } from 'reactstrap';
+import RoleSelect from './../RoleSelect/index.js'
+import { Button } from 'reactstrap'
+import { rolesDataKey } from './../RolesPermissions/index'
+
+const display = {
+  User: ["profile", "name"],
+  Roles: ["roles", rolesDataKey],
+  Events: ["events"]
+}
+
+const AdminTable = (props) => {
+  let titles = Object.keys(display);
+  const {users} = props;
+ 
+  return (
+    <Table>
+      <Head titles={titles}/>
+      <Rows usersData={users} display={display} titles={titles} events={props.events}
+        changeUserRole={props.changeUserRole} deleteUser={props.deleteUser}/>
+    </Table>
+  )
+}
+
+function Head(props) {
+  let titles = props.titles.map(ele => {
+    return <th key={ele}>{ele}</th>
+  })
+
+  return (
+    <thead>
+      <tr>
+        {titles}
+      </tr>
+    </thead>
+  )
+}
+
+function Rows(props){
+  const titles = props.titles;
+  const usersData = props.usersData
+  const display = props.display;
+
+  const tableRows = usersData.map(user => {
+    let button = <Button style={{ "marginRight": "4px" }} color='danger' onClick={(e) => props.deleteUser(user._id)}>del</Button>;
+    
+    return (
+      <tr key={user._id}>
+         {titles.map((title,i)=>{
+          let toDisplay = unpackDisplay(display[title], user) 
+          let isRoles = displayRoles(display[title], toDisplay, user, props.changeUserRole);
+          let isEvents = displayEvents(display[title], props.events, user);
+          if (isRoles){
+            toDisplay = isRoles;
+          }
+          if (isEvents){
+            toDisplay = isEvents
+          }
+          if (title !== "User"){
+            button = null;
+          }
+          return <td key={i}>{button}{toDisplay}</td>
+        })}
+      </tr>
+    )
+  })
+
+  return(
+    <tbody>
+      {tableRows}
+    </tbody>
+  )
+}
+
+function unpackDisplay(arrayKeys,userData){
+//Array.isArray(arrayKeys) && 
+  if (userData[arrayKeys[0]] != null){
+    let index = 0;
+    let value = userData;
+    while (index < arrayKeys.length  ) {    
+      
+      value = value[arrayKeys[index]]
+      index++;
+    }
+    return value;
+  }
+  return [];
+  // else{
+  //   
+  // }
+}
+
+function displayRoles(keys, roles, user, changeRole){
+  
+  let UserName = unpackDisplay(display['User'], user)
+  if (keys.indexOf(rolesDataKey) !== -1 ){
+
+    return <RoleSelect rolesData={roles} UserName={UserName} user={user} changeUserRole={changeRole}/>
+
+  }
+  else{
+    return false
+  }
+}
+
+function displayEvents(key, eventData, user){
+    const userEvents = eventData.filter(ele => {
+
+      return ele.organiser._id === user._id;
+    })
+  if (userEvents.length > 0 && key.indexOf('events') != -1){
+
+    return userEvents.map(ele => {
+      let id = ele._id
+      let name = ele.name;
+      let url = `/page/${id}`
+      return <Link key={ele._id} to={url}>{name} /</Link>
+    })
+   
+
+  }
+
+ 
+  return false;
+}
+
+
+export default AdminTable;

--- a/imports/client/ui/pages/Admin/RoleSelect/index.js
+++ b/imports/client/ui/pages/Admin/RoleSelect/index.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import {FormGroup, Label} from 'reactstrap';
+import { roleOptions} from "./../RolesPermissions/index"
+
+const RadioInput = (props) => {
+  const { rolesData } = props
+
+  //profile name could have duplication potential for users that sign in through google or facebook.
+  // using database id would expose it on the front end
+  // instead generate a unique id and use profile name/email
+  let name = generateUniqueId() + props.UserName;
+  return (
+    roleOptions.map((role,i) => {                                                 // check for default
+      let checked = (rolesData.indexOf(role) !== -1 || (rolesData.length == 0 && role == 'user')) ? "checked" :null;
+
+      return (
+        <Label check key={i}>
+          <input type="radio" value={role} name={name} defaultChecked={checked} 
+            onClick={(e) => props.changeUserRole(e, props.user._id)} key={i+name} />
+          {role}
+        </Label>
+      )
+    })
+
+  )
+}
+
+
+class RoleSelect extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {  }
+  }
+  render() { 
+    //current database documents do not contain roles yet so this is to check for their existance.
+    let rolesData = this.props.rolesData == null ? [] :  this.props.rolesData
+    return ( 
+      <div>
+        <FormGroup >
+          <RadioInput roleOptions={roleOptions} rolesData={rolesData} UserName={this.props.UserName} user={this.props.user} changeUserRole={this.props.changeUserRole}/>
+        </FormGroup>
+      </div>
+     )
+  }
+}
+
+
+function generateUniqueId() {
+  // code found here https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript?rq=1
+  try {
+    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
+      (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+    )
+    
+  } catch (error) {
+    // if an outaded browser is used use Math.random instead of es6 crypto
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+      var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+    
+  }
+}
+
+export default RoleSelect;

--- a/imports/client/ui/pages/Admin/RolesPermissions/index.js
+++ b/imports/client/ui/pages/Admin/RolesPermissions/index.js
@@ -6,8 +6,7 @@ export const permissions = {
   adminPage: ["admin", "moderator"],
   changeRole: ["admin"],
   deleteUser: ["admin"],
-  deleteResource: ["admin", "moderator"],
-  editResource: ["admin", "moderator"],
+  deleteEditResource: ["admin", "moderator"],
 }
 
 export const rolesDataKey = "__global_roles__";

--- a/imports/client/ui/pages/Admin/RolesPermissions/index.js
+++ b/imports/client/ui/pages/Admin/RolesPermissions/index.js
@@ -1,0 +1,28 @@
+import { Meteor } from "meteor/meteor";
+
+export const roleOptions = ["admin", "moderator", "user"]
+
+export const permissions = {
+  adminPage: ["admin", "moderator"],
+  changeRole: ["admin"],
+  deleteUser: ["admin"],
+  deleteResource: ["admin", "moderator"],
+  editResource: ["admin", "moderator"],
+}
+
+export const rolesDataKey = "__global_roles__";
+
+export const checkPermissions = (action) => {
+  const rolesAllowed = permissions[action];
+
+  const isPermission  = new Promise((resolve, reject) =>
+      Meteor.call('Admin.checkPermissions', { rolesAllowed }, (err, res) => {
+        if (err) {
+          reject(err);
+          throw new Meteor.Error('could not grant action')        
+        }
+          resolve(res);
+        })
+  );
+  return isPermission;
+}

--- a/imports/client/ui/pages/Admin/index.js
+++ b/imports/client/ui/pages/Admin/index.js
@@ -22,43 +22,41 @@ class Admin extends Component {
      }
   
   componentDidMount(){
-    this.getUsers();
+    checkPermissions('adminPage').then((isPermision) => {
+
+      if (!isPermision) {//!
+        this.props.history.goBack()//!
+      }//!
+    
+      this.getUsers();
+    });
   }
 
   componentDidUpdate(prevProps,prevState){
     if (this.state.users !== prevState.users && prevState.users){
-     // do a component should update on this
       this.getEvents();
     }
  
     if (prevProps.currentUser !== this.props.currentUser) {
       this.setState({ currentUser: this.props.currentUser });
     }
-
-    if (prevState.currentUser !== this.state.currentUser && this.state.currentUser){    
-      checkPermissions('adminPage').then((isPermision)=>{    
-
-          // if (!isPermision){
-          //   this.props.history.goBack() 
-          //  }
-
-        });
-    }
   }
 
   changeUserRole = (e, id) => {
-   const role = e.target.value;
-    handleChangeUserRole(role, id,this);
-    checkPermissions('changeRole').then((isPermision) => {
+    const role = e.target.value;
+    
+    checkPermissions('changeRole').then((isPermision) => {        
 
-      // if (!isPermision) {
-      //  this.setState({ alertNotAuthorized: true });
-      // }
-
+      if (!isPermision) {//!
+        this.setState({ alertNotAuthorized: true });//!
+      }//!
+      else{//!
+        handleChangeUserRole(role, id, this);
+      }//!
+      
     });
 
     function handleChangeUserRole(role,id,context) {
-   
       Meteor.call('Admin.changeRole', { id, role }, (err, res) => {
         if (err) {
           throw new Meteor.Error('could not change user')

--- a/imports/client/ui/pages/Admin/index.js
+++ b/imports/client/ui/pages/Admin/index.js
@@ -68,7 +68,8 @@ class Admin extends Component {
           const index = users.findIndex((ele) => {
             return ele._id === id;
           })
-          users[index].roles[rolesDataKey] = [role];
+          const roles = { [rolesDataKey]: [role] }
+          users[index].roles = roles;
           return {
             users
           }

--- a/imports/client/ui/pages/Admin/index.js
+++ b/imports/client/ui/pages/Admin/index.js
@@ -1,0 +1,191 @@
+import React, { Component, Fragment } from "react";
+import { Roles } from 'meteor/alanning:roles';
+import { Navbar, Nav, Alert , Button } from "reactstrap";
+import { NavLink as RouterNavLink } from "react-router-dom";
+import { Meteor } from "meteor/meteor";
+import { withTracker } from "meteor/react-meteor-data";
+import {rolesDataKey, checkPermissions } from "./RolesPermissions/index"
+import AdminTable from "./AdminTable/index"
+
+class Admin extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { 
+      users : [],
+      currentUser: {},
+      events: [],
+      limit: 25,
+      skip: 0,
+      isNoMoreUsers: false,
+      alertNotAuthorized : false,
+      }
+     }
+  
+  componentDidMount(){
+    this.getUsers();
+  }
+
+  componentDidUpdate(prevProps,prevState){
+    if (this.state.users !== prevState.users && prevState.users){
+     // do a component should update on this
+      this.getEvents();
+    }
+ 
+    if (prevProps.currentUser !== this.props.currentUser) {
+      this.setState({ currentUser: this.props.currentUser });
+    }
+
+    if (prevState.currentUser !== this.state.currentUser && this.state.currentUser){    
+      checkPermissions('adminPage').then((isPermision)=>{    
+
+          // if (!isPermision){
+          //   this.props.history.goBack() 
+          //  }
+
+        });
+    }
+  }
+
+  changeUserRole = (e, id) => {
+   const role = e.target.value;
+    handleChangeUserRole(role, id,this);
+    checkPermissions('changeRole').then((isPermision) => {
+
+      // if (!isPermision) {
+      //  this.setState({ alertNotAuthorized: true });
+      // }
+
+    });
+
+    function handleChangeUserRole(role,id,context) {
+   
+      Meteor.call('Admin.changeRole', { id, role }, (err, res) => {
+        if (err) {
+          throw new Meteor.Error('could not change user')
+        }
+        context.setState(currentState => {
+          let users = [...currentState.users]
+          const index = users.findIndex((ele) => {
+            return ele._id === id;
+          })
+          users[index].roles[rolesDataKey] = [role];
+          return {
+            users
+          }
+        });
+      })
+    }
+  }
+
+  deleteUser = (id) => {
+    checkPermissions('deleteUser').then((isPermision) => {
+      if (!isPermision) {
+        this.setState({ alertNotAuthorized:  true});
+      }
+      else{
+        handledeleteUser(this);
+      }
+  });
+
+    function handledeleteUser(context) {
+      Meteor.call('Admin.deleteUser', { id }, (err, res) => {
+        if (err) {
+          console.log('err', err);
+          throw new Meteor.Error('could not change delet')
+        }
+        context.setState(currentState => {
+          let userData = [...currentState.users];
+          const index = userData.findIndex((ele) => {
+            return ele._id === id;
+          })
+          userData.splice(index, 1);
+          return {
+            users : userData
+          }
+        });
+      })
+    }
+  }
+
+  displayMoreUsers = () =>{
+    let { skip, limit } = this.state;
+    skip = skip + limit;
+    this.setState({skip},()=>{
+      this.getUsers()
+    });
+  }
+
+  getUsers = () =>{
+    const {skip, limit} = this.state;
+    Meteor.call('Admin.getUsers', { skip, limit} , (err, res) => {
+      if (err) {
+        console.error('error', err)
+      }
+
+      if (res && res.length > 0) {
+        this.setState(currentState => {
+          res = this.nameOnly(res);
+          const users = currentState.users.concat(res);
+          return { users}
+        });
+      }
+      else{
+        this.setState({ isNoMoreUsers: true });
+      }
+    })
+  }
+
+  getEvents = () => {
+    const {users} = this.state;
+    let result = users.map(e => e._id);
+    Meteor.call('Admin.getEvents', { ids: result}, (err, res) => {
+      if (err) {
+        throw new Meteor.Error('could not find user...')
+      }
+      this.setState({ events: res });
+    })
+  }
+
+  addRoles = (id, role) =>{
+    Meteor.call('Admin.addRoles', { id, role}, (err, res) => {
+      if (err) {
+        throw new Meteor.Error('could not find user...')
+      }
+    })
+  }
+
+  nameOnly = (users) => { 
+    for (let index = 0, length = users.length; index < length; index++) {
+     let name = users[index].profile.name;
+      name = name.split('@');
+      users[index].profile.name = name[0];
+      
+    }
+    return users
+  }
+
+  render() {
+    const { isNoMoreUsers, events, alertNotAuthorized} = this.state;
+    return ( 
+      <div>
+        <AdminTable deleteUser={this.deleteUser} users={this.state.users} changeUserRole={this.changeUserRole} events={events}/>
+        <Button onClick={this.displayMoreUsers}>More</Button> 
+        {isNoMoreUsers && <Alert color="secondary">
+          No More Users
+        </Alert>
+        }
+        {alertNotAuthorized && <Alert color="secondary">
+          Not Authorized
+        </Alert>
+        }
+      </div>
+     )
+  }
+}
+ 
+export default withTracker(() => {
+  return {
+    currentUser: Meteor.user()
+  };
+
+})(Admin);

--- a/imports/client/ui/pages/NewEvent/index.js
+++ b/imports/client/ui/pages/NewEvent/index.js
@@ -159,6 +159,7 @@ class NewEventModal extends Component {
   deletePage = () => {
     let model = EventsSchema.clean(this.state.form.getModel())
     model._id = this.state.form.getModel()._id
+   
     this.callDeleteEvent(model);
   }
 
@@ -176,6 +177,7 @@ class NewEventModal extends Component {
   }
 
   callEditEvent = (model) => {
+    console.log('model', model);
     Meteor.call('Events.editEvent', model, (err, res) => {
       if (!err) {
         window.__updatedData = model // update event page.

--- a/imports/client/ui/pages/Page/index.js
+++ b/imports/client/ui/pages/Page/index.js
@@ -16,6 +16,7 @@ import {Helmet} from "react-helmet";
 import qs from 'query-string'
 import Linkify from 'linkifyjs/react'
 import i18n from '/imports/both/i18n/en'
+import { checkPermissions} from './../Admin/RolesPermissions/index'
 
 class Page extends Component {
   constructor (props) {
@@ -26,6 +27,7 @@ class Page extends Component {
       loaded: false,
       badges: null,
       redirect: false,
+      editDeletePermission: false,
     }
   }
 
@@ -44,11 +46,14 @@ class Page extends Component {
       this.setState({ loaded: true })
       window.__setDocumentTitle(data.name)
     }
+    this.deleteEditPermission();
+    
   }
 
   componentDidUpdate(prevProps, prevState) {
     if (this.state.data && !prevState.data) {
       window.__setDocumentTitle(this.state.data.name)
+    
     }
 
     // DOCUSS
@@ -133,7 +138,8 @@ class Page extends Component {
 
     const {
       data,
-      loaded
+      loaded,
+      editDeletePermission
     } = this.state
 
     if (!loaded) {
@@ -174,8 +180,12 @@ class Page extends Component {
     let isAuthor
 
     if (isLoggedIn) {
-      isAuthor = user._id === organiser._id
+      isAuthor = user._id === organiser._id 
     }
+    if (isLoggedIn && editDeletePermission){
+      isAuthor = editDeletePermission;
+    }
+
 
     return (
       <div id='page' onClick={e => this.dcsClick(null, e)}>
@@ -257,6 +267,13 @@ class Page extends Component {
   closePage = () =>{
     this.setState({ redirect: true });
   }
+
+  deleteEditPermission = () =>{
+    checkPermissions("deleteEditResource").then(response => {
+      this.setState({ editDeletePermission: response});
+    });
+  }
+
   scrollToMap(){
     scrollToElement('.embedded-map')
   }

--- a/imports/client/utils/adminControl.js
+++ b/imports/client/utils/adminControl.js
@@ -1,0 +1,7 @@
+import { Roles } from 'meteor/alanning:roles'
+import { Meteor } from "meteor/meteor";
+export function createAdmin(user) {
+  console.log('createAdminid', user._id);
+  console.log('Roles', Meteor.roles);
+  //Roles.addUsersToRoles(user._id, 'admin', Roles.GLOBAL_GROUP);
+}

--- a/imports/client/utils/adminControl.js
+++ b/imports/client/utils/adminControl.js
@@ -1,7 +1,0 @@
-import { Roles } from 'meteor/alanning:roles'
-import { Meteor } from "meteor/meteor";
-export function createAdmin(user) {
-  console.log('createAdminid', user._id);
-  console.log('Roles', Meteor.roles);
-  //Roles.addUsersToRoles(user._id, 'admin', Roles.GLOBAL_GROUP);
-}

--- a/server/methods/admin/addRole.js
+++ b/server/methods/admin/addRole.js
@@ -1,0 +1,35 @@
+import { Roles } from 'meteor/alanning:roles'
+import { Meteor } from "meteor/meteor";
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+import SimpleSchema from 'simpl-schema'
+import { logRateLimit } from '/server/security/rate-limiter'
+
+const name = 'Admin.addRole'
+const createAdmin = new ValidatedMethod({
+  name,
+  mixins: [],
+  validate: new SimpleSchema({
+    id: {
+      type: String,
+    },
+    Role: {
+      type: String,
+    }
+  }).validator(),
+  run({ id, Role }) { 
+
+    if (!id) {
+      throw new Meteor.Error('could not find user...')
+    }
+    Roles.addUsersToRoles(id, `${Role}`, Roles.GLOBAL_GROUP);
+  }
+})
+
+DDPRateLimiter.addRule({
+  name,
+  type: 'method'
+}, 2, 5000, ({ allowed }, { userId, clientAddress }) => { // 2 requests every 5 seconds
+  if (!allowed) {
+    logRateLimit(name, userId, clientAddress)
+  }
+})

--- a/server/methods/admin/changeRole.js
+++ b/server/methods/admin/changeRole.js
@@ -1,0 +1,37 @@
+import { Roles } from 'meteor/alanning:roles'
+import { Meteor } from "meteor/meteor";
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+import SimpleSchema from 'simpl-schema'
+import { logRateLimit } from '/server/security/rate-limiter'
+
+const name = 'Admin.changeRole'
+const changeRole = new ValidatedMethod({
+  name,
+  mixins: [],
+  validate: new SimpleSchema({
+    id: {
+      type: String,
+    },
+    role: {
+      type: String,
+    }
+  }).validator(),
+  run({ id, role }) {
+
+    if (!id) {
+      throw new Meteor.Error('could not find user...')
+    }
+
+   Roles.setUserRoles(id, `${role}`, Roles.GLOBAL_GROUP);
+
+  }
+})
+
+DDPRateLimiter.addRule({
+  name,
+  type: 'method'
+}, 4, 5000, ({ allowed }, { userId, clientAddress }) => { // 4 requests every 5 seconds
+  if (!allowed) {
+    logRateLimit(name, userId, clientAddress)
+  }
+})

--- a/server/methods/admin/checkPermissions.js
+++ b/server/methods/admin/checkPermissions.js
@@ -1,0 +1,34 @@
+import { Roles } from 'meteor/alanning:roles'
+import { Meteor } from "meteor/meteor";
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+import SimpleSchema from 'simpl-schema'
+import { logRateLimit } from '/server/security/rate-limiter'
+
+const name = 'Admin.checkPermissions'
+const changeRole = new ValidatedMethod({
+  name,
+  mixins: [],
+  validate: new SimpleSchema({
+
+    rolesAllowed: [String],
+ 
+  }).validator(),
+  run({rolesAllowed }) {
+    const id = this.userId
+    if (!id || !rolesAllowed) {
+      throw new Meteor.Error('could not find user...')
+    }
+
+  let permission = Roles.userIsInRole(id, rolesAllowed, Roles.GLOBAL_GROUP);
+  return permission;
+  }
+})
+
+DDPRateLimiter.addRule({
+  name,
+  type: 'method'
+}, 5, 5000, ({ allowed }, { userId, clientAddress }) => { // 5 requests every 5 seconds
+  if (!allowed) {
+    logRateLimit(name, userId, clientAddress)
+  }
+})

--- a/server/methods/admin/checkPermissions.js
+++ b/server/methods/admin/checkPermissions.js
@@ -15,6 +15,7 @@ const changeRole = new ValidatedMethod({
   }).validator(),
   run({rolesAllowed }) {
     const id = this.userId
+
     if (!id || !rolesAllowed) {
       throw new Meteor.Error('could not find user...')
     }

--- a/server/methods/admin/checkPermissions.js
+++ b/server/methods/admin/checkPermissions.js
@@ -5,7 +5,7 @@ import SimpleSchema from 'simpl-schema'
 import { logRateLimit } from '/server/security/rate-limiter'
 
 const name = 'Admin.checkPermissions'
-const changeRole = new ValidatedMethod({
+const checkPermissions = new ValidatedMethod({
   name,
   mixins: [],
   validate: new SimpleSchema({
@@ -16,11 +16,18 @@ const changeRole = new ValidatedMethod({
   run({rolesAllowed }) {
     const id = this.userId
 
-    if (!id || !rolesAllowed) {
+    if ( !rolesAllowed) {
       throw new Meteor.Error('could not find user...')
     }
 
-  let permission = Roles.userIsInRole(id, rolesAllowed, Roles.GLOBAL_GROUP);
+  let permission 
+  if (id == null){
+      permission = false;
+  }
+  else{
+      permission = Roles.userIsInRole(id, rolesAllowed, Roles.GLOBAL_GROUP);
+  }
+   
   return permission;
   }
 })

--- a/server/methods/admin/deleteUser.js
+++ b/server/methods/admin/deleteUser.js
@@ -1,0 +1,32 @@
+import { Roles } from 'meteor/alanning:roles'
+import { Meteor } from "meteor/meteor";
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+import SimpleSchema from 'simpl-schema'
+import { logRateLimit } from '/server/security/rate-limiter'
+
+const name = 'Admin.deleteUser'
+const createAdmin = new ValidatedMethod({
+  name,
+  mixins: [],
+  validate: new SimpleSchema({
+    id: {
+      type: String,
+    }
+  }).validator(),
+  run({ id}) {
+
+    if (!id) {
+      throw new Meteor.Error('could not find user...')
+    }
+    Meteor.users.remove({ _id: id })
+  }
+})
+
+DDPRateLimiter.addRule({
+  name,
+  type: 'method'
+}, 5, 5000, ({ allowed }, { userId, clientAddress }) => { // 5 requests every 5 seconds
+  if (!allowed) {
+    logRateLimit(name, userId, clientAddress)
+  }
+})

--- a/server/methods/admin/getEvents.js
+++ b/server/methods/admin/getEvents.js
@@ -1,0 +1,36 @@
+import { DDPRateLimiter } from 'meteor/ddp-rate-limiter'
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+import Events from '/imports/both/collections/events'
+import SimpleSchema from 'simpl-schema'
+import { logRateLimit } from '/server/security/rate-limiter'
+
+const name = 'Admin.getEvents'
+const getEvents = new ValidatedMethod({
+  name,
+  mixins: [],
+  validate: new SimpleSchema({
+    ids: [String],
+   
+  }).validator(),
+  run({ ids }) { 
+ 
+    const events = Events.find(
+      { "organiser._id": { "$in": ids } }, 
+      { fields: { '_id': 1, "organiser._id": 1, 'name': 1 } }
+    )
+    return events.fetch()
+  }
+})
+
+DDPRateLimiter.addRule({
+  name,
+  type: 'method'
+}, 5, 2000, ({ allowed }, { userId, clientAddress }) => { // 5 requests every 2 seconds
+  if (!allowed) {
+    logRateLimit(name, userId, clientAddress)
+  }
+})
+
+
+
+//{ "_id" : { "$in" : [ObjectId("55880c251df42d0466919268"), ObjectId("55bf528e69b70ae79be35006")] } }

--- a/server/methods/admin/getUsers.js
+++ b/server/methods/admin/getUsers.js
@@ -1,0 +1,36 @@
+import { Meteor } from "meteor/meteor";
+import { ValidatedMethod } from 'meteor/mdg:validated-method'
+import SimpleSchema from 'simpl-schema'
+import { logRateLimit } from '/server/security/rate-limiter'
+
+const name = 'Admin.getUsers'
+const getUsers = new ValidatedMethod({
+  name,
+  mixins: [],
+  validate: new SimpleSchema({
+    skip: {
+      type: Number,
+    },
+    limit: {
+      type: Number
+    }
+  }).validator(),
+  run({ skip, limit }) {
+
+   return Meteor.users.find({},
+     {
+       skip,
+       limit
+     }).fetch();
+
+  }
+})
+
+DDPRateLimiter.addRule({
+  name,
+  type: 'method'
+}, 5, 5000, ({ allowed }, { userId, clientAddress }) => { // 5 requests every 5 seconds
+  if (!allowed) {
+    logRateLimit(name, userId, clientAddress)
+  }
+})

--- a/server/methods/admin/index.js
+++ b/server/methods/admin/index.js
@@ -1,0 +1,6 @@
+import './addRole'
+import './changeRole'
+import './checkPermissions'
+import './deleteUser'
+import './getUsers'
+import './getEvents'

--- a/server/methods/events/deleteEvent.js
+++ b/server/methods/events/deleteEvent.js
@@ -29,7 +29,7 @@ const newEvent = new ValidatedMethod({
 
     const modelId = String(model._id) // ensure it's a string
 
-     Events.remove({ _id: modelId, 'organiser._id': userId }, (err) =>{
+     Events.remove({ _id: modelId}, (err) =>{
        if(err){
          throw new Meteor.Error('Events.deleteEvent', err)
        }

--- a/server/methods/events/editEvent.js
+++ b/server/methods/events/editEvent.js
@@ -28,7 +28,7 @@ const newEvent = new ValidatedMethod({
 
     const modelId = String(model._id) // ensure it's a string
 
-    const prevDoc = Events.find({ _id: modelId, 'organiser._id': userId }).fetch()[0]
+    const prevDoc = Events.find({ _id: modelId}).fetch()[0]
 
     if (prevDoc) {
       const newDoc = constructNewDocument(model, prevDoc)

--- a/server/methods/index.js
+++ b/server/methods/index.js
@@ -1,2 +1,3 @@
 import './events'
 import './general'
+import './admin'


### PR DESCRIPTION
Straight forward admin page. Admins can change user roles or delete them. Also, includes links to user posts so that moderators or admins can edit/delete the posts. There is a file that you will want to look at. imports\client\ui\pages\Admin\RolesPermissions\index.js because here you will see how the permissions are set. 
`export const roleOptions = ["admin", "moderator", "user"]

export const permissions = {
  adminPage: ["admin", "moderator"],
  changeRole: ["admin"],
  deleteUser: ["admin"],
  deleteEditResource: ["admin", "moderator"],
}` 
Right now only admins can delete users or change roles while both moderators and admins can delete or edit posts.  When you make a change to the user you will see an entry in the user document under roles.__global_roles__ in the database.
When you want to access the admin page just type /admin in the address bar after the url. When an admin is logged in they will see a link to the admin page in the drop down next to the logging out link. Instructions on How to get initial entry into admin page will be in the slack channel.  If you have any suggestions let me know and when you are happy will do the same for fl_sleeper.