### PR TITLE
Implement routing from discourse to whitepaper page (master)

### DIFF
--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -112,29 +112,6 @@ class App extends Component {
       }
     });
 
-  //   dcs.onTagOrTopic((tag, topicId) => {
-  //     if (isFromTheWhitepaperPage(tag)) { // Function to be designed
-  //       changeHistory({
-  //         pathname: "/whitepaper",
-  //         params: { r: "1", b: tag.substring(...), t: topicId || null },
-  //         push: false
-  //       });
-  // else {
-  //         Meteor.call("Events.getEventId", { discourseTag: tag }, (err, res) => {
-  //           if (err) {
-  //             console.log("Events.getEventId Error:", err);
-  //           } else {
-  //             this.triggeredByDiscourse = true;
-  //             changeHistory({
-  //               pathname: "/page/" + res,
-  //               params: { r: "1", b: tag.substring(...), t: topicId || null },
-  //               push: false
-  //             });
-  //           }
-  //         });
-  //       }
-  //     });
-
     // Setup callbacks to handle other Discourse events
     dcs.onUserChange(user => {
       //user && console.log('Unread notifications: ', user.unreadNotifications)

--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -90,19 +90,50 @@ class App extends Component {
       });
     });
     dcs.onTagOrTopic((tag, topicId) => {
-      Meteor.call("Events.getEventId", { discourseTag: tag }, (err, res) => {
-        if (err) {
-          console.log("Events.getEventId Error:", err);
-        } else {
-          this.triggeredByDiscourse = true;
-          changeHistory({
-            pathname: "/page/" + res,
-            params: { r: "1", b: tag.substring(17), t: topicId || null },
-            push: false
-          });
-        }
-      });
+      if (tag.includes('whitepaper')) {
+        changeHistory({
+          pathname: "/whitepaper",
+          params: { r: "1", b: tag.substring(17), t: topicId || null },
+          push: false
+        });
+      } else {
+        Meteor.call("Events.getEventId", { discourseTag: tag }, (err, res) => {
+          if (err) {
+            console.log("Events.getEventId Error:", err);
+          } else {
+            this.triggeredByDiscourse = true;
+            changeHistory({
+              pathname: "/page/" + res,
+              params: { r: "1", b: tag.substring(17), t: topicId || null },
+              push: false
+            });
+          }
+        });
+      }
     });
+
+  //   dcs.onTagOrTopic((tag, topicId) => {
+  //     if (isFromTheWhitepaperPage(tag)) { // Function to be designed
+  //       changeHistory({
+  //         pathname: "/whitepaper",
+  //         params: { r: "1", b: tag.substring(...), t: topicId || null },
+  //         push: false
+  //       });
+  // else {
+  //         Meteor.call("Events.getEventId", { discourseTag: tag }, (err, res) => {
+  //           if (err) {
+  //             console.log("Events.getEventId Error:", err);
+  //           } else {
+  //             this.triggeredByDiscourse = true;
+  //             changeHistory({
+  //               pathname: "/page/" + res,
+  //               params: { r: "1", b: tag.substring(...), t: topicId || null },
+  //               push: false
+  //             });
+  //           }
+  //         });
+  //       }
+  //     });
 
     // Setup callbacks to handle other Discourse events
     dcs.onUserChange(user => {


### PR DESCRIPTION
app.js now checks the discourse tag for the whitepaper page and adjusts history accordingly, so you don't get an undefined meteor page when you click on a topic link