### PR TITLE
Fix balloon tag forum post count (master)

### DIFF
--- a/imports/client/ui/components/DCSBalloon/index.js
+++ b/imports/client/ui/components/DCSBalloon/index.js
@@ -41,8 +41,8 @@ class DCSBalloon extends Component {
       const pathname = window.location.pathname
       const endIndex = pathname.search('\\?') > -1 ? pathname.search('\\?') : pathname.length
       const tagLocation = pathname.slice(pathname.search('/') + 1, endIndex)
-      const prefix = `dcs-${tagLocation}-${this.props.balloonId}`
-      const tag = this.props.dcsTags.find(tag => tag.id.startsWith(prefix))
+      const tagName = `dcs-${tagLocation}-${this.props.balloonId}`
+      const tag = this.props.dcsTags.find(tag => tag.id === tagName)
       const count = tag? tag.count : 0
       this.setState({ topicCount: count })
     }


### PR DESCRIPTION
Previously post count was looked up by using balloon id as _prefix_ which caused errors where multiple balloons had the same prefix. Switched to looking up the balloon id exactly as is (so far works as expected on whitepaper page based on a few tests).