### PR TITLE
 Enable double-level categories across event form and map filtering (sleeper) 

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -2,9 +2,14 @@ import { Meteor } from 'meteor/meteor'
 import { Mongo } from 'meteor/mongo'
 import SimpleSchema from 'simpl-schema'
 import { startingTime, endingTime, startingDate, endingDate, getHour, weekDays, getDate, videoHosts } from './helpers'
-import possibleCategories from '/imports/both/i18n/en/categories.json'
+import categoryTree from '/imports/both/i18n/en/categories.json'
 import labels from '/imports/both/i18n/en/new-event-modal.json'
 import DaySchema from './DaysSchema'
+
+// categoryTree includes parent-child level categories, following operation build an all-child array of sub-categories
+let possibleCategories = categoryTree.reduce((tot, elem) => {
+  return tot.concat([{name: elem.name, parent: true}].concat(elem.categories))
+}, [])
 
 // sets allowedValues to include Community Resource without it being in dropdown
 // someone should refactor this in the future: let allowedValues = possibleCategories.concat([{ 'name': 'Meet Me and Take #PublicHappiness to the Street', 'color': '#f82d2d' }])
@@ -35,8 +40,8 @@ const EventsSchema = new SimpleSchema({
   'organiser.name': {
     type: String
   },
-
-  // Categories
+  
+  // Categories sub level
   'categories': {
     type: Array,
     custom: function () {
@@ -48,11 +53,12 @@ const EventsSchema = new SimpleSchema({
       customType: 'select',
       selectOptions: {
         multi: true,
-        labelKey: 'name'
+        labelKey: 'name',
+        catLevel: 'child'
       },
       allowedValues: possibleCategories, // keep it here so options will be rendered by react-select
-      label: labels.categories,
-      placeholder_: 'Pick your event\'s categories'
+      label: null,
+      placeholder_: 'Additional category detail'
     }
   },
   'categories.$': {

--- a/imports/both/i18n/en/categories.json
+++ b/imports/both/i18n/en/categories.json
@@ -1,15 +1,18 @@
-[
-  { "name": "Community Offers", "color":"red", "default":true, "url": "https://www.reddit.com/r/brightertomorrow/" },
-  { "name": "Let’s End Homelessness Coffee Meeting", "color":"#94be29", "url": "" },
-  { "name": "Shower", "color":"#14fffc", "url": "" },
-  { "name": "Training Course", "color":"#181819", "url": "" },
-  { "name": "Activity", "color":"#63be29", "url": "" },
-  { "name": "Food", "color":"#e322e9", "url": "" },
-  { "name": "Clothes", "color":"#e2fe2e", "url": ""},
-  { "name": "Public Toilet", "color":"#63be29", "url": "" },
-  { "name": "Shelters", "color":"#74fe6a", "url": "" },
-  { "name": "Somewhere to Sleep", "color":"#6ab8fe", "url": "" },
-  { "name": "Computer or Wifi", "color":"#e4f81b", "url": "" },
-  { "name": "Public Library", "color":"#09bc2b", "url": "" },
-  { "name": "Medical", "color":"#fa0707", "url": "" }
-]
+  [{
+    "name": "Communities Supporting People",
+    "categories": [
+      { "name": "Community Offers", "color":"red", "default":true, "url": "https://www.reddit.com/r/brightertomorrow/" },
+      { "name": "Let’s End Homelessness Coffee Meeting", "color":"#94be29", "url": "" },
+      { "name": "Shower", "color":"#14fffc", "url": "" },
+      { "name": "Training Course", "color":"#181819", "url": "" },
+      { "name": "Activity", "color":"#63be29", "url": "" },
+      { "name": "Food", "color":"#e322e9", "url": "" },
+      { "name": "Clothes", "color":"#e2fe2e", "url": ""},
+      { "name": "Public Toilet", "color":"#63be29", "url": "" },
+      { "name": "Shelters", "color":"#74fe6a", "url": "" },
+      { "name": "Somewhere to Sleep", "color":"#6ab8fe", "url": "" },
+      { "name": "Computer or Wifi", "color":"#e4f81b", "url": "" },
+      { "name": "Public Library", "color":"#09bc2b", "url": "" },
+      { "name": "Medical", "color":"#fa0707", "url": "" }
+    ]
+  }]

--- a/imports/client/ui/components/VideoPlayer/index.js
+++ b/imports/client/ui/components/VideoPlayer/index.js
@@ -4,6 +4,7 @@ import ReactPlayer from 'react-player'
 import './styles.scss'
 import allPlaylists from '/imports/both/i18n/en/video.json'
 import Subscribe from '/imports/client/ui/components/VideoPlayer/Subscribe'
+import categoryTree from '/imports/both/i18n/en/categories.json'
 
 /**
  * @author Arty S
@@ -22,7 +23,7 @@ class VideoPlayer extends Component {
     /**
      * Refers to user submitted videos passed from the page, if any
      */
-    video: PropTypes.array,
+    video: PropTypes.object,
   }
 
   constructor (props) {
@@ -61,7 +62,8 @@ class VideoPlayer extends Component {
    */
   render () {
     const { categories, video } = this.props
-
+    console.log('categories in render func of video player:')
+    console.log(categories)
     return (
       <div
         className="videoContainer"
@@ -77,7 +79,7 @@ class VideoPlayer extends Component {
             this.setState({ nextVideo: true })
           }}
         />
-        <div className="subscribeOverlay">Subscribe</div>
+        {!video && <div className="subscribeOverlay">Subscribe</div>}
         {!video && <Subscribe className="subscribe" />}
       </div>
     )
@@ -137,15 +139,19 @@ function generatePlaylist (playlists, eventCategories, outputArray) {
     })
   })
 
-  // NOTE: if event category does not have a playlist then we take the parent category instead
+  // NOTE: if event category does not have a playlist then we take the parent category instead and re-run
   if (outputArray.length === 0) {
-    parentCategories = eventCategories.map(eventCategory => {
-      return {name: eventCategory.parent}
+    const parentCategories = categoryTree.filter(parent => {
+      // filter to include only parent groups, with at least 1 child present in the event's category array
+      const hasCategoryAsChild = parent.categories.some(category =>
+        eventCategories.some(eventCategory =>
+          eventCategory.name === category.name))
+      return hasCategoryAsChild
     })
     generatePlaylist(playlists, parentCategories, outputArray)
   }
 
-  // NOTE: if parent does not have a playlist either then we generate a grand default
+  // NOTE: if parent does not have a playlist either then we generate a grand default and re-run
   if (outputArray.length === 0) {
     generatePlaylist(playlists, [{ 'name': 'default' }], outputArray)
   }

--- a/imports/client/ui/pages/Map/EventsFilter/index.js
+++ b/imports/client/ui/pages/Map/EventsFilter/index.js
@@ -38,7 +38,7 @@ class FiltersList extends Component {
       show,
       toggleFiltersList
     } = this.props
-    console.log(checkedFilters)
+    
     return (
       <div id='filters-list' className={show ? 'show' : ''}>
         <ListGroup>

--- a/imports/client/ui/pages/Map/EventsFilter/index.js
+++ b/imports/client/ui/pages/Map/EventsFilter/index.js
@@ -38,7 +38,7 @@ class FiltersList extends Component {
       show,
       toggleFiltersList
     } = this.props
-
+    console.log(checkedFilters)
     return (
       <div id='filters-list' className={show ? 'show' : ''}>
         <ListGroup>
@@ -97,7 +97,7 @@ class FiltersList extends Component {
         // parent currently UNCHECKED: means you are CHECKING, so children should unhide (so set to false)
         possibleCategories[index].hidden = parentChecked? true: false
       }
-      while (!checkedFilters[index + 1].parent)
+      while (checkedFilters[index + 1] && !checkedFilters[index + 1].parent)
     }
   }
 
@@ -139,7 +139,7 @@ class FiltersList extends Component {
     do {
       tempIndex++
       checkedFilters[tempIndex].checked = parentChecked
-    } while (!checkedFilters[tempIndex + 1].parent)
+    } while (checkedFilters[tempIndex + 1] && !checkedFilters[tempIndex + 1].parent)
     return checkedFilters
   }
 
@@ -154,7 +154,7 @@ class FiltersList extends Component {
     do {
       tempIndex++
       if (checkedFilters[tempIndex].checked) allUnchecked = false
-    } while (!checkedFilters[tempIndex + 1].parent)
+    } while (checkedFilters[tempIndex + 1] && !checkedFilters[tempIndex + 1].parent)
     // if all are unchecked, set parent to unchecked and hide all the children
     if (allUnchecked) {
       checkedFilters[parentIndex].checked = false
@@ -162,7 +162,7 @@ class FiltersList extends Component {
       do {
         tempIndex++
         possibleCategories[tempIndex].hidden = true
-      } while (!checkedFilters[tempIndex + 1].parent)
+      } while (checkedFilters[tempIndex + 1] && !checkedFilters[tempIndex + 1].parent)
     }
     return {checkedFilters, possibleCategories}
   }

--- a/imports/client/ui/pages/Map/EventsFilter/index.js
+++ b/imports/client/ui/pages/Map/EventsFilter/index.js
@@ -1,14 +1,31 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { ListGroup, ListGroupItem, CustomInput } from 'reactstrap'
-import possibleCategories from '/imports/both/i18n/en/categories.json'
+import categoryTree from '/imports/both/i18n/en/categories.json'
 import i18n from '/imports/both/i18n/en'
 import './styles.scss'
 
+// categoryTree includes parent-child level categories, following operation build an all-child array of sub-categories
+// the last function elem.categories.map(...) adds an additional 'hidden' field to each subscategory for UI purposes
+let possibleCategories = categoryTree.reduce((tot, elem) => {
+  return tot.concat([{ name: elem.name, parent: true }].concat(elem.categories.map(category => {
+    category.hidden = true
+    return category
+  })))
+}, [])
+
+// We need the list of parent categories in order to disable them in the category dropdown
+// (because these are subheadings in the dropdown -> user selects the actual child category instead)
+const parentCategories = categoryTree.map(elem => elem.name)
+
 class FiltersList extends Component {
   state = {
-    checkAll: true,
-    checkedFilters: Array(possibleCategories.length).fill(true) // all checked by default
+    checkAll: false,
+    checkedFilters: possibleCategories.map(elem => {
+      elem.checked = false; // all unchecked by default
+      return elem
+    })
+    // checkedFilters: Array(possibleCategories.length).fill(true) // all checked by default
   }
 
   render () {
@@ -26,7 +43,7 @@ class FiltersList extends Component {
       <div id='filters-list' className={show ? 'show' : ''}>
         <ListGroup>
           <ListGroupItem className='title'>
-            <div>{i18n.Map.filtersTitle}</div>
+            <div><span>{i18n.Map.filtersTitle}</span></div>
             <i className='fa fa-times close' onClick={toggleFiltersList}/>
             <CustomInput
               id='toggle-all'
@@ -38,13 +55,22 @@ class FiltersList extends Component {
           <div className='categories-items'>
             {possibleCategories.map((category, index) => {
               return (
-                <ListGroupItem key={index} style={{ color: category.color }}>
+                <ListGroupItem
+                  key={index}
+                  className="checkbox"
+                  style={{
+                    marginLeft: category.parent !== true? '20px':'0px' ,
+                    color: category.color,
+                    display: category.hidden === true? 'none':'block'
+                  }}
+                >
                   <CustomInput
                     id={'filter-' + index}
                     type='checkbox'
                     label={category.name}
-                    checked={checkedFilters[index]}
+                    checked={checkedFilters[index].checked}
                     onChange={this.handleFilterChange}
+                    onClick={category.parent === true && this.expandCategory}
                   />
                   { category.url && 
                     <a href={category.url} target='_blank' rel='external' aria-label='Go to Page'>
@@ -60,25 +86,97 @@ class FiltersList extends Component {
     )
   }
 
-  handleFilterChange = ({ target }) => {
+  expandCategory = ({ target }) => {
     const checkedFilters = [...this.state.checkedFilters]
-    const index = target.id.split('-')[1]
-
-    if (checkedFilters[index]) {
-      checkedFilters[index] = false
-    } else {
-      checkedFilters[index] = true
+    let index = target.id.split('-')[1]
+    if (checkedFilters[index].parent) {
+      const parentChecked = checkedFilters[index].checked
+      do {
+        index++
+        // parent currently CHECKED: means you are UNCHECKING, means children should become hidden (so set to true)
+        // parent currently UNCHECKED: means you are CHECKING, so children should unhide (so set to false)
+        possibleCategories[index].hidden = parentChecked? true: false
+      }
+      while (!checkedFilters[index + 1].parent)
     }
+  }
+
+  handleFilterChange = ({ target }) => {
+    let checkedFilters = [...this.state.checkedFilters]
+    let index = target.id.split('-')[1]
+    // console.log(checkedFilters)
+    if (checkedFilters[index].checked) {
+      checkedFilters[index].checked = false
+    } else {
+      checkedFilters[index].checked = true
+    }
+
+    // if parent, then the tick needs to be propagating to all its child categories
+    if (checkedFilters[index].parent) {
+      checkedFilters = this.propagateChecksToChildren(checkedFilters, index)
+    }
+
+    // if child, then need to check whether all siblings are unticked
+    // if all siblings unticked -> untick parent (by setting checkedFilters array)
+    //                             and hide children (by setting possibleCategories array)
+    if (!checkedFilters[index].parent) {
+      const modifiedCategories = this.propagateChecksToParent(checkedFilters, possibleCategories, index)
+      checkedFilters = modifiedCategories.checkedFilters
+      possibleCategories = modifiedCategories.possibleCategories
+    }
+
     this.setState({ checkedFilters })
-    this.props.onFilter(this.applyFilter(checkedFilters))
+
+    // applyFilter function is designed to work on a simple array with true/false values
+    // so we map back our array of objects (checkedFilters) into an array of true/false values
+    this.props.onFilter(this.applyFilter(checkedFilters.map(e => e.checked)))
+  }
+
+  propagateChecksToChildren = (checkedFilters, index) => {
+    // if the checkbox selected belongs to a parent category we apply the change to all its children:
+    const parentChecked = checkedFilters[index].checked
+    let tempIndex = index
+    do {
+      tempIndex++
+      checkedFilters[tempIndex].checked = parentChecked
+    } while (!checkedFilters[tempIndex + 1].parent)
+    return checkedFilters
+  }
+
+  propagateChecksToParent = (checkedFilters, possibleCategories, index) => {
+    // if the checkbox is a child category, and all siblings are unchecked, uncheck the parent
+    let tempIndex = index
+    // traverse array back to the parent
+    while (!checkedFilters[tempIndex].parent) tempIndex--
+    // save parent index, then move through all the children of this group and verify all are unchecked
+    const parentIndex = tempIndex
+    let allUnchecked = true
+    do {
+      tempIndex++
+      if (checkedFilters[tempIndex].checked) allUnchecked = false
+    } while (!checkedFilters[tempIndex + 1].parent)
+    // if all are unchecked, set parent to unchecked and hide all the children
+    if (allUnchecked) {
+      checkedFilters[parentIndex].checked = false
+      let tempIndex = parentIndex
+      do {
+        tempIndex++
+        possibleCategories[tempIndex].hidden = true
+      } while (!checkedFilters[tempIndex + 1].parent)
+    }
+    return {checkedFilters, possibleCategories}
   }
 
   toggleAllFilters = () => {
     const checkAll = !this.state.checkAll
-    const checkedFilters = Array(possibleCategories.length).fill(checkAll)
+    const checkedFilters = possibleCategories.map(elem => {
+      elem.checked = checkAll; // all checked by default
+      return elem
+    })
 
     this.setState({ checkedFilters, checkAll })
-    this.props.onFilter(this.applyFilter(checkedFilters))
+    // same as above - we turn the array of objects into simple array of true/false values
+    this.props.onFilter(this.applyFilter((checkedFilters.map(e => e.checked))))
   }
 
   applyFilter = (checkedFilters) => {

--- a/imports/client/ui/pages/Map/EventsFilter/styles.scss
+++ b/imports/client/ui/pages/Map/EventsFilter/styles.scss
@@ -26,8 +26,15 @@
   .title {
     height: calc(100% + 20px);
     position: relative;
-    text-align: center;
+    text-align: left;
     font-weight: bolder;
+
+    div {
+      position: relative;
+      span {
+        padding-left: 23px;
+      }
+    }
 
     .close {
       position: absolute;
@@ -46,13 +53,21 @@
   .categories-items{
     .list-group-item{
       display: flex;
-        align-items: flex-start;
-        flex-flow: row nowrap;
-        justify-content: space-between;
+      align-items: flex-start;
+      flex-flow: row nowrap;
+      justify-content: space-between;
+    
+      position: relative;
+
+      div {
+        display: inline-block;
+      }
     }
 
     .list-group-item a{
       color: $gray-stronger;
+      position: absolute;
+      right: 20px;
 
       &:hover {
         color: $primary-blue-hover;

--- a/imports/client/utils/uniforms-custom/SelectField.js
+++ b/imports/client/utils/uniforms-custom/SelectField.js
@@ -2,9 +2,14 @@ import React, { Component } from 'react'
 import connectField from 'uniforms/connectField'
 import Select from 'react-select'
 import PlacesSearchBox from '/imports/client/ui/components/PlacesSearchBox'
+import categoryTree from '/imports/both/i18n/en/categories.json'
 import { formatReactSelectOptions } from '../format'
 
 import { FormGroup, Label } from 'reactstrap'
+
+// We need the list of parent categories in order to disable them in the category dropdown
+// (because these are subheadings in the dropdown -> user selects the actual child category instead)
+const parentCategories = categoryTree.map(elem => elem.name)
 
 class Select_ extends Component {
   constructor (props) {
@@ -39,7 +44,7 @@ class Select_ extends Component {
     const className = 'select-field ' + (error ? 'error' : '')
 
     let value_ = this.getValues(value)
-  
+
     return (
       <FormGroup className={className}>
         <Label>{label}</Label>
@@ -58,12 +63,25 @@ class Select_ extends Component {
         {!url && !googleMaps && (
           <Select
             value={value_}
-            options={options}
+            // options={options}
+            options={options.map(elem => {
+              // NOTE: this adds custom styling to options that are in fact parent categories (style them as subheadings)
+              if (parentCategories.includes(elem.label)) {
+                return {
+                  value: elem.value,
+                  label: `---${elem.label}---`
+                }
+              } else return elem
+            })}
             isMulti={multi}
             onChange={this.handleChange}
             placeholder={''}
             isSearchable={false}
             menuPlacement='auto'
+            isOptionDisabled={(option) => {
+              // NOTE: this stops user from being able to select options that are in fact parent categories
+              return parentCategories.includes(option.label.slice(3, option.label.length-3))
+            }}
           />
         )}
         {googleMaps && (


### PR DESCRIPTION
Equivalent to [PR #973 on master](https://github.com/focallocal/fl-maps/pull/973)

Currently all BTM categories roll up into 1 parent 'Communities Supporting People' but this can be changed or expanded in i18n.