### PR TITLE
Enable line-break rendering (master)

### DIFF
--- a/imports/client/ui/pages/Page/style.scss
+++ b/imports/client/ui/pages/Page/style.scss
@@ -19,6 +19,10 @@ $titles-color: #fff;
     }
   }
 
+  .body * {
+    white-space: pre-wrap;
+  }
+
   .body {
     width: 80%;
     margin: 24px auto;


### PR DESCRIPTION
Relates to [this issue on trello](https://trello.com/c/sKvcvQZh/573-bug-pages-preserve-spaces-paragraphs-line-breaks-etc)

It's a very short/quick css fix once you know about it :)

Copied the text block presented on trello and included a double line break before 'Important Notes' and single line breaks before each numbered list item to test:

**Example before:**
![Screenshot from 2019-04-23 11-27-51](https://user-images.githubusercontent.com/26905074/56574503-4a383c80-65bb-11e9-935f-74d3730560fb.png)
**Example after:
![Screenshot from 2019-04-23 11-27-42](https://user-images.githubusercontent.com/26905074/56574526-58865880-65bb-11e9-9981-0b1034459497.png)
**
