### PR TITLE
New widgets/buttons to auto-share event details on social media (master)

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -65,7 +65,7 @@ const EventsSchema = new SimpleSchema({
       },
       allowedValues: possibleCategories, // keep it here so options will be rendered by react-select
       label: null,
-      placeholder_: 'Additional category detail'
+      placeholder_: 'Event Categories'
     }
   },
   'categories.$': {

--- a/imports/both/i18n/en/map.json
+++ b/imports/both/i18n/en/map.json
@@ -17,6 +17,11 @@
     "experiences": {
       "title": "Community Experiences",
       "subtitle": "How was your Experience? (positive/negative)"
+    },
+    "socialMedia": {
+      "title": "Social Media",
+      "subtitle": "Support Us By Sharing This Event",
+      "messagePre": "Check out this event: "
     }
   }
 }

--- a/imports/client/ui/components/SharePanel/index.js
+++ b/imports/client/ui/components/SharePanel/index.js
@@ -50,8 +50,9 @@ class SharePanel extends Component {
     const hoursText = drillDownToText(hoursReactComponent, '')
 
     const url = 'https://focallocal.org/page/fGd8HuHZEv8QectPS'
-    const title = i18n.Map.eventInfo.socialMedia.messagePre + document.title + "\n" + hoursText + "\n"
-    console.log(title)
+    const string = i18n.Map.eventInfo.socialMedia.messagePre + document.title + "\n" + hoursText + "\n"
+    const title = string.replace(' Next:', 'Next:').replace(' Repeating:', '\nRepeating:')
+    
     return (
       <div className="sharePanel">
         <FacebookShareButton url={url} quote={title} hashtag="#Focallocal" children={<FacebookIcon size={32} round={true} />} />
@@ -65,13 +66,27 @@ class SharePanel extends Component {
   }
 }
 
-
+/**
+ * This function takes the html-formatted React output of the 'when' component (i.e. event calendar schedule)
+ * and returns a plain text string representing this schedule
+ * 
+ * @param {Object} node This is React component or child node (see below comments for different possible node types)
+ * @param {String} output This is a running total of the output string - the function adds to this as it drills recursively into the node
+ */
 function drillDownToText (node, output) {
   const children = node.props.children
   children.forEach(child => {
-    if (typeof child === 'string') output += child
-    else if (typeof child !== 'boolean') {
-      output = drillDownToText(child, output)
+    if (child) {
+      // Function has drilled down to the string? => add this to output 
+      if (typeof child === 'string') output += child
+      // Replace any <br> and <li> tags with whitespace (otherwise words on a newLine get mushed together)
+      else if (child.type === 'br' || child.type === 'li') {
+        output += ' '
+      }
+      // If the node has further children we continue drilling down until we get to the strings
+      if (child.props && child.props.children) {
+        output = drillDownToText(child, output)
+      }
     }
   })
   return output

--- a/imports/client/ui/components/SharePanel/index.js
+++ b/imports/client/ui/components/SharePanel/index.js
@@ -55,8 +55,8 @@ class SharePanel extends Component {
     
     return (
       <div className="sharePanel">
-        <FacebookShareButton url={url} quote={title} hashtag="#Focallocal" children={<FacebookIcon size={32} round={true} />} />
-        <TwitterShareButton url={url} title={title} hashtags={['Focallocal']} children={<TwitterIcon size={32} round={true} />} />
+        <FacebookShareButton url={url} quote={title} hashtag="#publichappinessmovement" children={<FacebookIcon size={32} round={true} />} />
+        <TwitterShareButton url={url} title={title} hashtags={['publichappinessmovement']} children={<TwitterIcon size={32} round={true} />} />
         <RedditShareButton url={url} title={title} children={<RedditIcon size={32} round={true} />} />
         <LinkedinShareButton url={url} title={title} description={title} children={<LinkedinIcon size={32} round={true} />} />
         <EmailShareButton url={url} subject={title} children={<EmailIcon size={32} round={true} />} />

--- a/imports/client/ui/components/SharePanel/index.js
+++ b/imports/client/ui/components/SharePanel/index.js
@@ -36,7 +36,7 @@ import './styles.scss'
  */
 
 // NOTE: testing facebook share on local machine will lead to an error page if target domain is localhost
-// const url = window.location
+// const url = window.location <-- set this to a live www. url to test
 
 class SharePanel extends Component {
 
@@ -49,7 +49,7 @@ class SharePanel extends Component {
     const hoursReactComponent = HoursFormatted({ data: this.props.data })
     const hoursText = drillDownToText(hoursReactComponent, '')
 
-    const url = 'https://focallocal.org/page/fGd8HuHZEv8QectPS'
+    const url = window.location
     const string = i18n.Map.eventInfo.socialMedia.messagePre + document.title + "\n" + hoursText + "\n"
     const title = string.replace(' Next:', 'Next:').replace(' Repeating:', '\nRepeating:')
     

--- a/imports/client/ui/components/SharePanel/index.js
+++ b/imports/client/ui/components/SharePanel/index.js
@@ -1,0 +1,80 @@
+import {
+  FacebookShareButton,
+  GooglePlusShareButton,
+  LinkedinShareButton,
+  TwitterShareButton,
+  TelegramShareButton,
+  WhatsappShareButton,
+  PinterestShareButton,
+  VKShareButton,
+  OKShareButton,
+  RedditShareButton,
+  TumblrShareButton,
+  LivejournalShareButton,
+  MailruShareButton,
+  ViberShareButton,
+  WorkplaceShareButton,
+  LineShareButton,
+  EmailShareButton,
+
+  FacebookIcon,
+  LinkedinIcon,
+  TwitterIcon,
+  RedditIcon,
+  EmailIcon
+} from 'react-share'
+import React, { Component, Fragment } from 'react'
+import HoursFormatted from '/imports/client/ui/components/HoursFormatted'
+import PropTypes from 'prop-types'
+import i18n from '/imports/both/i18n/en'
+import './styles.scss'
+
+/**
+ * @author Arty S
+ * Share Panel Component: Loads a series of social media buttons.
+ * users can use these to share the event page
+ */
+
+// NOTE: testing facebook share on local machine will lead to an error page if target domain is localhost
+// const url = window.location
+
+class SharePanel extends Component {
+
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+
+    const hoursReactComponent = HoursFormatted({ data: this.props.data })
+    const hoursText = drillDownToText(hoursReactComponent, '')
+
+    const url = 'https://focallocal.org/page/fGd8HuHZEv8QectPS'
+    const title = i18n.Map.eventInfo.socialMedia.messagePre + document.title + "\n" + hoursText + "\n"
+    console.log(title)
+    return (
+      <div className="sharePanel">
+        <FacebookShareButton url={url} quote={title} hashtag="#Focallocal" children={<FacebookIcon size={32} round={true} />} />
+        <TwitterShareButton url={url} title={title} hashtags={['Focallocal']} children={<TwitterIcon size={32} round={true} />} />
+        <RedditShareButton url={url} title={title} children={<RedditIcon size={32} round={true} />} />
+        <LinkedinShareButton url={url} title={title} description={title} children={<LinkedinIcon size={32} round={true} />} />
+        <EmailShareButton url={url} subject={title} children={<EmailIcon size={32} round={true} />} />
+      </div>
+    )
+
+  }
+}
+
+
+function drillDownToText (node, output) {
+  const children = node.props.children
+  children.forEach(child => {
+    if (typeof child === 'string') output += child
+    else if (typeof child !== 'boolean') {
+      output = drillDownToText(child, output)
+    }
+  })
+  return output
+}
+
+export default SharePanel

--- a/imports/client/ui/components/SharePanel/styles.scss
+++ b/imports/client/ui/components/SharePanel/styles.scss
@@ -1,0 +1,10 @@
+.sharePanel {
+  display: flex;
+  justify-content: space-evenly;
+  padding-top: 10px;
+
+  div {
+    display: inline;
+    cursor: pointer;
+  }
+}

--- a/imports/client/ui/components/VideoPlayer/index.js
+++ b/imports/client/ui/components/VideoPlayer/index.js
@@ -62,8 +62,6 @@ class VideoPlayer extends Component {
    */
   render () {
     const { categories, video } = this.props
-    console.log('categories in render func of video player:')
-    console.log(categories)
     return (
       <div
         className="videoContainer"

--- a/imports/client/ui/pages/Page/index.js
+++ b/imports/client/ui/pages/Page/index.js
@@ -9,6 +9,7 @@ import { scrollToElement } from '/imports/client/utils/DOMInteractions'
 import HoursFormatted from '/imports/client/ui/components/HoursFormatted'
 import VideoPlayer from '/imports/client/ui/components/VideoPlayer'
 import PageLoader from '/imports/client/ui/components/PageLoader'
+import SharePanel from '/imports/client/ui/components/SharePanel'
 import EditPage from './Edit'
 // import AttendingButton from './AttendingButton'  <-- currently disabled
 import './style.scss'
@@ -186,7 +187,6 @@ class Page extends Component {
       isAuthor = editDeletePermission;
     }
 
-
     return (
       <div id='page' onClick={e => this.dcsClick(null, e)}>
         <div className='header'>
@@ -228,7 +228,7 @@ class Page extends Component {
               <SectionTitle title='Date and Time' />
               {/* attending button currently inactive until able to work with both maps:
                 <AttendingButton _id={_id} history={history} isLoggedIn={isLoggedIn} user={user} />*/}
-              <HoursFormatted data={when} />
+              <HoursFormatted data={when}/>
 
               <Divider />
 
@@ -239,6 +239,15 @@ class Page extends Component {
               </div>
 
               <Divider />
+
+              <div className='social'>
+                <SectionTitle title={i18n.Map.eventInfo.socialMedia.title} />
+                <p className='social__subheading'>{i18n.Map.eventInfo.socialMedia.subtitle}</p>
+                <SharePanel data={when}/>
+              </div>
+
+              <Divider />
+
               {isAuthor && <EditPage data={data} history={history} />} 
               <Button color='danger' onClick={ this.closePage}>Close Page</Button>
             </Col>

--- a/imports/client/ui/pages/Page/style.scss
+++ b/imports/client/ui/pages/Page/style.scss
@@ -104,6 +104,12 @@ $titles-color: #fff;
         }
       }
 
+      .social {
+        .social__subheading {
+          font-size: 0.75em;
+        }
+      }
+
       .btn {
         width: 100%;
         margin-bottom: 8px;

--- a/imports/client/utils/uniforms-custom/SelectField.js
+++ b/imports/client/utils/uniforms-custom/SelectField.js
@@ -75,7 +75,7 @@ class Select_ extends Component {
             })}
             isMulti={multi}
             onChange={this.handleChange}
-            placeholder={''}
+            placeholder={placeholder_}
             isSearchable={false}
             menuPlacement='auto'
             isOptionDisabled={(option) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3933,7 +3933,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -8215,6 +8214,14 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
+      "requires": {
+        "debug": "2.6.9"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -9944,8 +9951,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mup": {
       "version": "1.4.5",
@@ -20224,6 +20230,17 @@
         "raf": "3.4.0",
         "react-input-autosize": "2.2.1",
         "react-transition-group": "2.3.1"
+      }
+    },
+    "react-share": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-2.4.0.tgz",
+      "integrity": "sha512-PlVs9Z0/ma0LDaVOPC9uWEysucoL2OOnBEFu7m4TjFMiS42KmHDTW9k9L4LOCCpxiHemfrg/EkzHuU2YXJHn8g==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.5",
+        "jsonp": "0.2.1",
+        "prop-types": "15.6.1"
       }
     },
     "react-side-effect": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-select": "^2.0.0-beta.2",
+    "react-share": "^2.4.0",
     "react-swipeable": "^4.3.0",
     "reactstrap": "^6.0.1",
     "remarkable": "^1.7.1",


### PR DESCRIPTION
This is at least a partial solution to [this issue on Trello](https://trello.com/c/Uxv4Ts8N/503-key-task-links-added-to-pages?menu=filter&filter=label:Meteor%20Dev)

Event pages now have share buttons for the main social media + email, on clicking user gets a popup to confirm share, which is pre-populated with link to event page, together with the event title and the date and time of the event (wording can be edited in i18n).