### PR TITLE
Allow users to hide map filter window on mobile screen (master)

### DIFF
--- a/imports/client/ui/pages/Map/EventsList/MinimizeButton/index.js
+++ b/imports/client/ui/pages/Map/EventsList/MinimizeButton/index.js
@@ -2,22 +2,29 @@ import React from 'react'
 import { Button } from 'reactstrap'
 import './styles.scss'
 
-const MinimizeButton = ({ onMinimize }) => {
-  let minimized = false
+export default class MinimizeButton extends React.Component {
+  constructor() {
+    super()
+    this.state = {
+      minimized: false
+    }
+  }
 
-  try {
-    minimized = document.body.querySelector('#map-container').classList.contains('minimized')
-  } catch (ex) {}
+  toggleMinimize = () => {
+    this.setState({ minimized: !this.state.minimized })
+    document.body.querySelector('#map-container').classList.toggle('minimized')
+  }
 
-  return (
-    <Button
-      id='minimize'
-      className={minimized ? 'minimized' : ''}
-      onClick={onMinimize}
-    >
-      {minimized ? 'maximize' : 'minimize'}
-    </Button>
-  )
+  render() {
+    const { minimized } = this.state
+    return (
+      <Button
+        id='minimize'
+        className={minimized ? 'minimized' : ''}
+        onClick={this.toggleMinimize}
+      >
+        {minimized ? 'maximize' : 'minimize'}
+      </Button>
+    )
+  }
 }
-
-export default MinimizeButton

--- a/imports/client/ui/pages/Map/EventsList/index.js
+++ b/imports/client/ui/pages/Map/EventsList/index.js
@@ -63,7 +63,7 @@ class EventsList extends Component {
           <NoResults show={!hasData && !isFetching} />
         </div>
 
-        <MinimizeButton onMinimize={this.toggleMinimize} />
+        <MinimizeButton />
 
         <EventInfo
           event={events.find(event => event._id === currentEvent)}
@@ -75,10 +75,6 @@ class EventsList extends Component {
         />
       </Fragment>
     )
-  }
-
-  toggleMinimize = () => {
-    document.body.querySelector('#map-container').classList.toggle('minimized')
   }
 
   returnToList = () => {

--- a/imports/client/ui/pages/Map/mobile-styles.scss
+++ b/imports/client/ui/pages/Map/mobile-styles.scss
@@ -4,9 +4,39 @@
 
   #map-container {
 
+    #minimize {
+      position: fixed;
+      top: calc(100vh - 30px - (55vh - #{$menu-height}));
+      left: 0px;
+      height: 30px;
+      width: 76.2px;
+      font-size: .7em;
+      background-color: $gray-lighter;
+      color: $black-lighter;
+      transform: rotateZ(0deg);
+      transition: top .2s ease;
+    }
+
+    &.minimized {
+
+      #events-list, #event-info {
+        transform: translateY(calc(55vh - #{$menu-height}));
+      }
+
+      #map {
+        height: 100%!important;
+      }
+
+      button#minimize {
+        top: calc(100vh - 30px);
+        left: 0px;
+      }
+    }
+
     #map {
       height: calc(55vh - #{$menu-height});
       width: 100% !important;
+      transition: height .2s ease;
     }
 
     #events-list {
@@ -16,10 +46,6 @@
       height: calc(55vh - #{$menu-height});
       width: 100%;
       transform: translateX(0);
-    }
-
-    #minimize {
-      display: none;
     }
 
     #filters-list {


### PR DESCRIPTION
Relates to [this issue on Trello](https://trello.com/c/M8FU8GPB/469-on-mobile-in-portrait-vertical-users-cant-close-the-filters-window-on-main-map-page).

Added a button to minimize/maximize the menu on mobile screens. Same format as in desktop version only the hiding movement happens downwards (instead of leftwards):

Screenshot of minimized menu (with 'maximize' button to re-open menu when needed):
![Screenshot from 2019-05-01 14-26-45](https://user-images.githubusercontent.com/26905074/57019480-92d8a100-6c1e-11e9-92fb-a8c33495fad5.png)

