### PR TITLE
Configured router to a new 404 page for non-listed URL paths (master)

### DIFF
--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -26,6 +26,7 @@ import Map_ from "./pages/Map";
 import NewEventLoadable from "./pages/NewEvent/loadable";
 import CongratsModal from "./pages/NewEvent/CongratsModal";
 import Page from "./pages/Page";
+import { Error404 } from "./pages/Errors";
 
 // Components
 import ScrollToTop from "./components/ScrollToTop";
@@ -182,6 +183,21 @@ class App extends Component {
       dcsClick: this.dcsClick.bind(this)
     };
 
+    const routePaths = {
+      root: "/",
+      home: "/home",
+      team: "/team",
+      partners: "/partners",
+      whitepaper: "/whitepaper",
+      faq: "/faq",
+      about: "/about",
+      map: "/map",
+      admin: "/admin",
+      thankyou: "/thank-you",
+      page: "/page",
+      signin: "/sign-in"
+    }
+
     return (
       <div id="dcs-root" className={dcsClass}>
         <div
@@ -199,18 +215,19 @@ class App extends Component {
               <MainMenu />
 
               <ScrollToTop>
-                <Route exact path="/(home)?" component={Home} />
-                <Route exact path="/team" render={props => <Team {...props} {...dcsProps} />} />
-                <Route exact path="/partners" render={props => <Partners {...props} {...dcsProps} />} />
-                <Route exact path="/whitepaper" render={props => <Whitepaper {...props} {...dcsProps} />} />
-                <Route exact path="/faq" render={props => <Faq {...props} {...dcsProps} />}/>
-                <Route exact path="/about" render={props => <About {...props} {...dcsProps} />}/>
-                <Route path="/map" component={Map_} />
-                <Route exact path="/admin" render={props => <Admin {...props}/>} /> 
-                <Route path="*" render={this.renderNewEvent} />
-                <Route exact path="/thank-you" component={CongratsModal} />
-                <Route exact path="/page/:id" render={props => <Page {...props} {...dcsProps} />}
-                />
+                <Route exact path={routePaths.root} component={Home} />
+                <Route exact path={routePaths.home} component={Home} />
+                <Route exact path={routePaths.team} render={props => <Team {...props} {...dcsProps} />} />
+                <Route exact path={routePaths.partners} render={props => <Partners {...props} {...dcsProps} />} />
+                <Route exact path={routePaths.whitepaper} render={props => <Whitepaper {...props} {...dcsProps} />} />
+                <Route exact path={routePaths.faq} render={props => <Faq {...props} {...dcsProps} />}/>
+                <Route exact path={routePaths.about} render={props => <About {...props} {...dcsProps} />}/>
+                <Route path={routePaths.map} component={Map_} />
+                <Route exact path={routePaths.admin} render={props => <Admin {...props}/>} /> 
+                <Route exact path={routePaths.thankyou} component={CongratsModal} />
+                <Route exact path={`${routePaths.page}/:id`} render={props => <Page {...props} {...dcsProps} />}/>
+
+                <Route path="*" render={() => this.check404Route(Object.values(routePaths))} />
 
                 <Authentication />
               </ScrollToTop>
@@ -276,11 +293,30 @@ class App extends Component {
       return <Redirect to='/home' />
     }
     */
-
+    console.log('passed in loc:\n', location)
+    console.log('passed in hist:\n', history)
     return (
       <NewEventLoadable isOpen={isOpen} location={location} history={history} />
     );
   };
+
+  /**
+   * This function manages the 'catch-all' route, serving two purposes.
+   * (1) open a model to create/edit event when there is the appropriate search string in the URL
+   * (2) for all other routes not specified, it will redirect to a 404 page
+   * Ideally we should be using React-router Switch to create a fallback 404 page...
+   * But this would require opening the new event modal without using the URL as a hook
+   * And this may break interactions with Docus (e.g. editing an event directly from the forum)
+   */ 
+  check404Route = (routes) => {
+    if (window.location.search === '?new=1' || window.location.search === '?edit=1') {
+      return this.renderNewEvent({ location: window.location, history })
+    }
+    if (!routes.some(e => e === window.location.pathname) && !window.location.pathname.includes('/page/')) {
+      return <Error404 />
+    }
+    return null
+  }
 }
 
 export default hot(module)(App);

--- a/imports/client/ui/pages/Errors/index.js
+++ b/imports/client/ui/pages/Errors/index.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import './styles.scss'
+
+export const Error404 = (props) => {
+  return (
+    <div className="error__container">
+      <h3 className="error__heading">Page not found</h3>
+      <br/>
+      <p className="error__paragraph">Use the menu bar above to navigate the site.</p>
+    </div>
+  )
+}

--- a/imports/client/ui/pages/Errors/styles.scss
+++ b/imports/client/ui/pages/Errors/styles.scss
@@ -1,0 +1,8 @@
+.error__container {
+  padding: 20vh;
+
+  .error__heading, .error__paragraph {
+    margin: auto;
+    text-align: center
+  }
+}


### PR DESCRIPTION
Relates to [this issue on trello](https://trello.com/c/w7wO45sc/282-both-key-task-create-a-404-page-not-found-page).

The page itself is pretty basic, but works around all the other components so shouldn't interfere if you then click on "Gather" to add a new event.

![Screenshot from 2019-05-06 13-00-11](https://user-images.githubusercontent.com/26905074/57223816-3ea73580-6fff-11e9-9678-f8fc3e4fa791.png)
