### PR TITLE
Bugfix - 404 page triggered by some valid paths that were not part of main router (master)

### DIFF
--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -195,7 +195,11 @@ class App extends Component {
       admin: "/admin",
       thankyou: "/thank-you",
       page: "/page",
-      signin: "/sign-in"
+      signin: "/sign-in",
+      signup: "/sign-up",
+      change_password: "/change-password",
+      forgot_password: "/forgot-password",
+      sso_auth: "/sso_auth"
     }
 
     return (
@@ -312,8 +316,10 @@ class App extends Component {
     if (window.location.search === '?new=1' || window.location.search === '?edit=1') {
       return this.renderNewEvent({ location: window.location, history })
     }
-    if (!routes.some(e => e === window.location.pathname) && !window.location.pathname.includes('/page/')) {
-      return <Error404 />
+    if (!routes.some(e => e === window.location.pathname)
+      && !window.location.pathname.includes('/page/')
+      && !window.location.pathname.includes('reset-password')) {
+        return <Error404 />
     }
     return null
   }


### PR DESCRIPTION
Just came across a second nested (hidden) react router that was part of the app's authentication component, with a couple of url paths dedicated to auths, such as '/reset-password' and '/forgot-password'.

As these were not part of the main app logic they were triggering the 404 page so I had to tweak the 404 page router manually.