### PR TITLE
Attempted repair whitepaper sub-pages

### DIFF
--- a/imports/both/i18n/en/index.js
+++ b/imports/both/i18n/en/index.js
@@ -7,6 +7,7 @@ import NewEventModal from "./new-event-modal.json";
 import Team from "./team.json";
 import Partners from "./partners.json";
 import Faq from "./faq.json";
+import Whitepaper from "./whitepaper";
 
 export default {
   About,
@@ -17,5 +18,6 @@ export default {
   NewEventModal,
   Team,
   Partners,
-  Faq
+  Faq,
+  Whitepaper
 };

--- a/imports/both/i18n/en/whitepaper/index.js
+++ b/imports/both/i18n/en/whitepaper/index.js
@@ -1,0 +1,9 @@
+import Faqs from "./faqs.json";
+import Intro from "./intro.json";
+import Why from "./why.json";
+
+export default {
+  Intro,
+  Why,
+  Faqs
+};

--- a/imports/client/ui/app.js
+++ b/imports/client/ui/app.js
@@ -28,6 +28,10 @@ import CongratsModal from "./pages/NewEvent/CongratsModal";
 import Page from "./pages/Page";
 import { Error404 } from "./pages/Errors";
 
+import WPIntro from "./pages/WhitePaper/Intro";
+import WPWhy from "./pages/WhitePaper/Why";
+import WPFAQs from "./pages/WhitePaper/faqs"; 
+
 // Components
 import ScrollToTop from "./components/ScrollToTop";
 import Admin from "./pages/Admin/index"
@@ -199,7 +203,11 @@ class App extends Component {
       signup: "/sign-up",
       change_password: "/change-password",
       forgot_password: "/forgot-password",
-      sso_auth: "/sso_auth"
+      sso_auth: "/sso_auth",
+
+      whitepaper_intro: "/whitepaper/intro",
+      whitepaper_why: "/whitepaper/why",
+      whitepaper_faqs: "/whitepaper/faqs"
     }
 
     return (
@@ -230,6 +238,10 @@ class App extends Component {
                 <Route exact path={routePaths.admin} render={props => <Admin {...props}/>} /> 
                 <Route exact path={routePaths.thankyou} component={CongratsModal} />
                 <Route exact path={`${routePaths.page}/:id`} render={props => <Page {...props} {...dcsProps} />}/>
+
+                <Route exact path={routePaths.whitepaper_intro} render={props => <WPIntro {...props} {...dcsProps} />} />
+                <Route exact path={routePaths.whitepaper_why} render={props => <WPWhy {...props} {...dcsProps} />} />
+                <Route exact path={routePaths.whitepaper_faqs} render={props => <WPFAQs {...props} {...dcsProps} />} />
 
                 <Route path="*" render={() => this.check404Route(Object.values(routePaths))} />
 

--- a/imports/client/ui/pages/WhitePaper/Intro/FirstSection/index.js
+++ b/imports/client/ui/pages/WhitePaper/Intro/FirstSection/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Row, Col } from 'reactstrap'
-import i18n from '/imports/both/i18n/en/whitepaper'
-import '././styles.scss'
+import i18n from '/imports/both/i18n/en/'
+import '././style.scss'
 
 const { title, content } = i18n.Whitepaper.Intro.first_section
 const {

--- a/imports/client/ui/pages/WhitePaper/Intro/SecondSection/index.js
+++ b/imports/client/ui/pages/WhitePaper/Intro/SecondSection/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Row, Col } from 'reactstrap'
-import i18n from '/imports/both/i18n/en/whitepaper'
-import '././styles.scss'
+import i18n from '/imports/both/i18n/en/'
+import '././style.scss'
 
 const { title, content } = i18n.Whitepaper.Intro.second_section
 const {

--- a/imports/client/ui/pages/WhitePaper/Intro/TopImageSection/index.js
+++ b/imports/client/ui/pages/WhitePaper/Intro/TopImageSection/index.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Container, Row, Col } from 'reactstrap'
-import i18n from '/imports/both/i18n/en/whitepaper'
-import '././styles.scss'
+import i18n from '/imports/both/i18n/en/'
+import './style.scss'
 
-const { content } = i18n.Intro.whitepaper.first_section
+console.log(i18n.Whitepaper)
+const { content } = i18n.Whitepaper.Intro.first_section
 const {top_image_url} = content
 
 const TopImageSection = () => (

--- a/imports/client/ui/pages/WhitePaper/Intro/index.js
+++ b/imports/client/ui/pages/WhitePaper/Intro/index.js
@@ -2,11 +2,11 @@ import React, { Component } from 'react'
 import TopImageSection from './TopImageSection'
 import FirstSection from './FirstSection'
 import SecondSection from './SecondSection'
-import AboutSection from '../Home/SecondSection'
-import i18n from '/imports/both/i18n/en/whitepaper'
-import './styles.scss'
+// import AboutSection from '../Home/SecondSection'
+import i18n from '/imports/both/i18n/en/'
+import './style.scss'
 
-class About extends Component {
+class Intro extends Component {
   componentDidMount () {
     window.__setDocumentTitle('Intro')
   }
@@ -18,7 +18,7 @@ class About extends Component {
         <h2>Intro</h2>
         <div className='header-divider' />
         <TopImageSection />
-        <AboutSection button= {false} />
+        {/* <AboutSection button= {false} /> */}
         <FirstSection />
         <SecondSection />
       </div>

--- a/imports/client/ui/pages/WhitePaper/Why/Content.js
+++ b/imports/client/ui/pages/WhitePaper/Why/Content.js
@@ -1,7 +1,7 @@
 //Imports
 import React from "react";
 import { Container, Row, Col } from "reactstrap";
-import i18n from "../../../../../both/i18n/en/why";
+import i18n from "/imports/both/i18n/en/";
 import DCSBalloon from '/imports/client/ui/components/DCSBalloon/index.js'
 
 const Content = (props) => {
@@ -13,7 +13,7 @@ const Content = (props) => {
           Take a look at frequently asked questions          
         </p>
       </Container>
-      {i18n.Whitepaper.why.Faq.faq.map((item, index) => {
+      {i18n.Whitepaper.Why.faq.map((item, index) => {
         return (
           <Col key={index} className="ml-5 pl-5 mt-5" xs={11}>
             <h3>{item.heading} </h3>

--- a/imports/client/ui/pages/WhitePaper/faqs/Content.js
+++ b/imports/client/ui/pages/WhitePaper/faqs/Content.js
@@ -1,7 +1,7 @@
 //Imports
 import React from "react";
 import { Container, Row, Col } from "reactstrap";
-import i18n from "../../../../../both/i18n/en/whitepaper";
+import i18n from "/imports/both/i18n/en/";
 import DCSBalloon from '/imports/client/ui/components/DCSBalloon/index.js'
 
 const Content = (props) => {


### PR DESCRIPTION
Changed three areas to be able to display the new pages:

- new pages were added to i18n folder without wiring up the import/export of the data in an index.js file (the fix is in the first two changed files below)
- the new URLs need to be added to the router in app.js (the fix is in the third file change below)
- some small typos dotted about in the whitepaper folder which throw errors when trying to compile (fix is in the remaining file changes below)

NOTE: looks like the content under why/ and faq/ in 18n is currently the same so the pages looks exactly the same - assume it will be updated further down the line?