### PR TITLE
Categories placeholder

### DIFF
--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -70,7 +70,7 @@ const EventsSchema = new SimpleSchema({
       },
       allowedValues: possibleCategories, // keep it here so options will be rendered by react-select
       label: null,
-      placeholder_: 'Event Categories'
+      placeholder_: i18n.categories
     }
   },
   'categories.$': {

--- a/imports/both/collections/events/index.js
+++ b/imports/both/collections/events/index.js
@@ -70,7 +70,7 @@ const EventsSchema = new SimpleSchema({
       },
       allowedValues: possibleCategories, // keep it here so options will be rendered by react-select
       label: null,
-      placeholder_: i18n.categories
+      placeholder_: labels.categories
     }
   },
   'categories.$': {


### PR DESCRIPTION
@AndyatFocallocal  'Event Categories' was hard coded into the schema. I fixed it to be dynamic. However, I am not sure if the brightertomorrow live site is even using the correct code. It does not seem to be using the same code as publichappinesss.  I think it is still using the fl-sleeper  I found this line in the readme  

- *settings.json* has a property named `'mapType': 'gatherings'` ,
     you can change 'gatherings' to 'btm' to work on Focallocal or Brighter Tomorrow

When I changed the setting to btm it looked different from the live site. It looked more like publichappiness with correct links instead of bubbles and a btm logo on top left.

Fixing this problem https://publichappinessmovement.com/t/topic/1610/2