### PR TITLE
Change event time selection from dropdown to basic +/- buttons

### DIFF
--- a/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
@@ -83,6 +83,17 @@ class SecondStep extends Component {
                         </div>
                       </Fragment>
                     )}
+                    {repeat && (
+                      <Fragment>
+                        <Label className="large-only">&nbsp;</Label>
+                        <div className="date-hours-single conditional-time">
+                          <AutoField
+                            name="when.endingTime"
+                            customType="timePicker"
+                          />
+                        </div>
+                      </Fragment>
+                    )}
                   </Fragment>
                 )}
                 {!repeat && openEndDate && (

--- a/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
+++ b/imports/client/ui/pages/NewEvent/FormWizard/SecondStep.js
@@ -1,14 +1,12 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { CustomInput, Row, Col, Button } from 'reactstrap'
-// import labels from '/imports/both/i18n/en/new-event-modal.json'
+import { CustomInput, Row, Col, Button, Label } from 'reactstrap'
 import AutoField from '/imports/client/utils/uniforms-custom/AutoField'
 import ErrorField from '/imports/client/utils/uniforms-custom/ErrorField'
 import Recurring from './DateTimeModule/Recurring'
 import WeekDays from './DateTimeModule/WeekDays'
 import VideoLink from './VideoLink'
 import SameDateHours from './SameDateHours'
-import { videoHosts } from '/imports/both/collections/events/helpers'
 
 import i18n from '/imports/both/i18n/en'
 
@@ -40,61 +38,82 @@ class SecondStep extends Component {
     } = form.getModel().when
 
     return (
-      <div id='second-step'>
-        <AutoField name='findHints' />
-        <div className='dates-hours inline-inputs hide-labels'>
+      <div id="second-step">
+        <AutoField name="findHints" />
+        <div className="dates-hours inline-inputs hide-labels">
           <div>
-            <Row>
-              <Col className='date-hours-coupled'>
-                <AutoField name='when.startingDate' />
-                {!multipleDays && <AutoField name='when.startingTime' />}
+            <Row className="date-hours-box">
+              <Col className="date-hours-coupled">
+                <Label>Active from</Label>
+                <div className="date-hours-single">
+                  <AutoField name="when.startingDate" label={false} />
+                  {/* {!multipleDays && <AutoField name="when.startingTime" />} */}
+                  {!multipleDays && (
+                    <AutoField
+                      name="when.startingTime"
+                      customType="timePicker"
+                    />
+                  )}
+                </div>
               </Col>
-              <Col className='date-hours-coupled'>
-                {(!repeat && !openEndDate) && <AutoField
-                  name='when.endingDate'
-                  specialCat={this.props.form.getModel().categories.some(e => {
-                    return e.name === 'Community Offer' || e.name === 'Meet me for Action!'
-                  })}
-                />}
-                {(!multipleDays && !openEndDate) && <AutoField name='when.endingTime' />}
-                {(!repeat && openEndDate) && (
-                  <AutoField
-                    name='when.endingDate'
-                    openEndDate={true}
-                    handleCalendarClick={this.resetEndDate}
-                  />
+              <Col className="date-hours-coupled">
+                {!openEndDate && (
+                  <Fragment>
+                    {!repeat && (
+                      <Fragment>
+                        <Label>Active until</Label>
+                        <div className="date-hours-single">
+                          <AutoField
+                            name="when.endingDate"
+                            specialCat={this.props.form
+                              .getModel()
+                              .categories.some(e => {
+                                return (
+                                  e.name === 'Community Offer' ||
+                                  e.name === 'Meet me for Action!'
+                                );
+                              })}
+                          />
+                          {!multipleDays && (
+                            <AutoField
+                              name="when.endingTime"
+                              customType="timePicker"
+                            />
+                          )}
+                        </div>
+                      </Fragment>
+                    )}
+                  </Fragment>
+                )}
+                {!repeat && openEndDate && (
+                  <Fragment>
+                    <Label>Active until</Label>
+                    <AutoField
+                      name="when.endingDate"
+                      openEndDate={true}
+                      handleCalendarClick={this.resetEndDate}
+                    />
+                  </Fragment>
                 )}
               </Col>
             </Row>
           </div>
-          {/*
-          <div>
-            <Row>
-              <Col>
-                {!multipleDays && <AutoField name='when.startingTime' />}
-              </Col>
-              <Col>
-                {!multipleDays && <AutoField name='when.endingTime' />}
-              </Col>
-            </Row>
-          </div>
-          */}
         </div>
 
         {/* Weekdays  */}
         <RadioButton
-          id='multipleDays'
+          id="multipleDays"
           label={labels.recurrence.thirdRadio}
           value={multipleDays}
-          type='radio'
+          type="radio"
         />
         {multipleDays && (
-          <div className='week-days'>
-            <ErrorField name='when.days' errorMessage='Please select at least 1 day' />
-            <SameDateHours
-              form={form}
-              schemaKey={'when.days'}
+          <div className="week-days">
+            <ErrorField
+              name="when.days"
+              errorMessage="Please select at least 1 day"
             />
+            <SameDateHours form={form} schemaKey={'when.days'} />
             <WeekDays
               form={form}
               schemaKey={'when.days'}
@@ -105,22 +124,22 @@ class SecondStep extends Component {
 
         {/* Repetition */}
         <RadioButton
-          id='repeat'
+          id="repeat"
           label={labels.recurrence.fourthRadio}
           value={repeat}
-          type='radio'
+          type="radio"
         />
         {repeat && <Recurring form={form} />}
 
         {/* Additional text description & attendee limit */}
-        <AutoField className='pageDetails' name='description' />
-        <AutoField className='pageDetails' name='engagement.limit' />
+        <AutoField className="pageDetails" name="description" />
+        <AutoField className="pageDetails" name="engagement.limit" />
 
         {/* Add video link(s) */}
         <CustomInput
           className="videoToggle"
-          id='includesVideo'
-          type='radio'
+          id="includesVideo"
+          type="radio"
           label={`${labels.video.title.firstLine}
                 ${labels.video.title.secondLine}`}
           checked={videoLinksAdded > 0}
@@ -129,13 +148,15 @@ class SecondStep extends Component {
         {videoLinksAdded > 0 && <VideoEntry id={1} form={form} />}
         {videoLinksAdded > 1 && <VideoEntry id={2} form={form} />}
         {videoLinksAdded > 2 && <VideoEntry id={3} form={form} />}
-        {videoLinksAdded > 0 && <VideoButtons
-          videoLinksAdded={videoLinksAdded}
-          addLink={this.addLink}
-          removeLink={this.removeLink}
-        />}
+        {videoLinksAdded > 0 && (
+          <VideoButtons
+            videoLinksAdded={videoLinksAdded}
+            addLink={this.addLink}
+            removeLink={this.removeLink}
+          />
+        )}
       </div>
-    )
+    );
   }
 
   toggleLinks = () => {

--- a/imports/client/ui/pages/NewEvent/styles.scss
+++ b/imports/client/ui/pages/NewEvent/styles.scss
@@ -157,6 +157,18 @@
   #second-step  {
 
     @media (max-width: 575px) {
+      .large-only {
+        display: none;
+      }
+      .conditional-time {
+        &::before {
+          width: 45%;
+          content: ""
+        }
+        .select-field::before {
+          width: 45%;
+        }
+      }
       .date-hours-box {
         flex-direction: column;
         .date-field, .select-field {

--- a/imports/client/ui/pages/NewEvent/styles.scss
+++ b/imports/client/ui/pages/NewEvent/styles.scss
@@ -154,11 +154,45 @@
              Second Step
      ----------------------------- */
 
-  #second-step{
+  #second-step  {
+
+    @media (max-width: 575px) {
+      .date-hours-box {
+        flex-direction: column;
+        .date-field, .select-field {
+          width: 45%;
+        }
+        .time-display {
+          min-width: 60px;
+        }
+      }
+    }
     .date-hours-coupled {
-      .select-field{
-        position: relative;
-        top: -1em;
+      .date-hours-single {
+        display: flex;
+      }
+      .date-field {
+        label {display: none}
+      }
+      .select-field {
+        padding-left: 0.5em;
+        .time-box {
+          display: flex;
+          width: 115px;
+          .time-display {
+            border: 1px solid rgb(206, 212, 218);
+            border-left: none;
+            border-right: none;
+            height: 100%;
+            padding: 6px;
+            margin: 0px;
+            width: 75px;
+            text-align: center;
+          }
+          .time-btn {
+            border: 1px solid rgb(206, 212, 218);
+          }
+        }
       }
     }
   }

--- a/imports/client/utils/uniforms-custom/AutoField.js
+++ b/imports/client/utils/uniforms-custom/AutoField.js
@@ -6,6 +6,7 @@ import DateField from './DateField'
 import InputField from './InputField'
 import NumberField from './NumberField'
 import SelectField from './SelectField'
+import TimePicker from './TimePicker'
 
 export default class AutoField extends BaseField {
     static displayName = 'AutoField';
@@ -23,6 +24,7 @@ export default class AutoField extends BaseField {
           case 'select': props.component = SelectField; break
           case 'textarea': props.component = InputField; break
           case 'number': props.component = InputField; break
+          case 'timePicker': props.component = TimePicker; break
         }
       } else {
         switch (fieldType) {

--- a/imports/client/utils/uniforms-custom/TimePicker.js
+++ b/imports/client/utils/uniforms-custom/TimePicker.js
@@ -1,0 +1,78 @@
+import React, { Component } from 'react';
+import connectField from 'uniforms/connectField';
+import { FormGroup, Label, Button, ButtonGroup } from 'reactstrap';
+
+import { formatReactSelectOptions } from '../format';
+
+class TimePicker_ extends Component {
+  constructor(props) {
+    super();
+    const { labelKey, labelMapper } = props.selectOptions || {};
+
+    this.state = {
+      options: formatReactSelectOptions(
+        props.allowedValues,
+        labelKey,
+        labelMapper
+      ),
+      index: props.allowedValues.indexOf(props.value)
+    };
+  }
+
+  render() {
+    const { value, error } = this.props;
+
+    const className = 'select-field ' + (error ? 'error' : '');
+
+    const buttonProps = {
+      outline: true,
+      color: 'secondary'
+    };
+
+    const clockProps = {
+      color: 'secondary'
+    };
+
+    return (
+      <FormGroup className={className}>
+        <ButtonGroup className="time-box">
+          <Button className="time-btn" {...buttonProps} onClick={this.decTime}>
+            -
+          </Button>
+          <Label className="time-display" {...clockProps}>
+            {value}
+          </Label>
+          <Button className="time-btn" {...buttonProps} onClick={this.incTime}>
+            +
+          </Button>
+        </ButtonGroup>
+      </FormGroup>
+    );
+  }
+
+  incTime = () => {
+    if (this.state.index === this.props.allowedValues.length - 1) {
+      this.props.onChange(
+        this.props.allowedValues[0]
+      );
+      this.setState({ index: 0 });
+      return
+    }
+    this.props.onChange(this.props.allowedValues[this.state.index + 1]);
+    this.setState({ index: this.state.index + 1 });
+  };
+
+  decTime = () => {
+    if (this.state.index === 0) {
+      this.props.onChange(
+        this.props.allowedValues[this.props.allowedValues.length - 1]
+      );
+      this.setState({ index: this.props.allowedValues.length - 1 });
+      return
+    }
+    this.props.onChange(this.props.allowedValues[this.state.index - 1]);
+    this.setState({ index: this.state.index - 1 });
+  };
+}
+
+export default connectField(TimePicker_);


### PR DESCRIPTION
Had a go at designing the clock change buttons. Currently we only save the time in increments of 30min in the database, so to work around that I just have one "minus 30min" button and another "plus 30 min" button.

The flow is decent though, as especially on a mobile it's more intuitive to hit the button a few times until you find the desired time, instead of opening up a sub-menu and then trying to scroll.

Tested locally with both standard and repeating events - creates successfully, but let me know if you spot anything that doesn't look right.

Let me know what you think.

Screenshot:

**Standard Desktop:**
![Standard_desktop](https://user-images.githubusercontent.com/26905074/76171308-8186ec00-6181-11ea-8e18-1048f9f22f91.png)
**Standard on Mobile:**
![Standard_mobile](https://user-images.githubusercontent.com/26905074/76171309-821f8280-6181-11ea-8f2c-4cba1d797396.png)
**Repeating Event on Desktop:**
![Repeating_desktop](https://user-images.githubusercontent.com/26905074/76171306-80ee5580-6181-11ea-8dd6-059e48e42c08.png)
**Repeating Event on Mobile:**
![Repeating_mobile](https://user-images.githubusercontent.com/26905074/76171307-8186ec00-6181-11ea-967c-2e9424cd4783.png)
