### PR TITLE
Handle empty endingDate

### DIFF
--- a/imports/client/ui/components/HoursFormatted/index.js
+++ b/imports/client/ui/components/HoursFormatted/index.js
@@ -11,8 +11,6 @@ const HoursFormatted = ({ data }) => {
     endingTime
   } = data
 
-  const isSameDay = startingDate.toDateString() === endingDate.toDateString()
-
   if (data.multipleDays) {
     const isEnding = !!endingDate
 
@@ -34,6 +32,8 @@ const HoursFormatted = ({ data }) => {
       </div>
     )
   }
+
+  const isSameDay = startingDate.toDateString() === endingDate.toDateString();
 
   if (data.repeat) {
     const {


### PR DESCRIPTION
I don't think new events can be entered with an empty `endingDate` anymore, but there are a couple of older ones on btm that have one when they're set to `multipleDays`.

The highlighted statement throws an error, but if we just move it down it should be fine as the function gets caught by the `multipleDays` catch and returns before it gets to the erroring statement (it should have been down there all along tbh).

Tested locally by manually adding into my mongo the Crisis Skylight event @TLMcNulty included in the conversation thread - it's able to display now.

![Screenshot from 2020-04-09 23-39-18](https://user-images.githubusercontent.com/26905074/78946729-6fb7a200-7abb-11ea-925f-fb14faa7ae1e.png)
