### PR TITLE
Change zodern-meteor version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - cd deployment/$(./deployment/branch-to-dir.sh "$TRAVIS_BRANCH")
   - for file in *.enc*; do sops --decrypt --output "${file%.enc*}${file##*.enc}" "${file}"; done
   - npm install -g mup
-  - curl https://install.meteor.com/?release=2.11.0 | /bin/sh
+  - curl https://install.meteor.com | /bin/sh
 
 branches:
   only:

--- a/deployment/brightertomorrowmap/mup.js
+++ b/deployment/brightertomorrowmap/mup.js
@@ -12,7 +12,7 @@ module.exports = {
     name: 'brightertomorrowmap',
     path: '../../.',
     docker: {
-      image: 'zodern/meteor:latest'
+      image: 'zodern/meteor:root'
     },
     servers: {
       one: {}

--- a/deployment/publichappinessmovement/mup.js
+++ b/deployment/publichappinessmovement/mup.js
@@ -12,7 +12,7 @@ module.exports = {
     name: 'publichappinessmovement',
     path: '../../.',
     docker: {
-      image: 'zodern/meteor:latest'
+      image: 'zodern/meteor:root'
     },
     servers: {
       one: {}

--- a/deployment/testing/mup.js
+++ b/deployment/testing/mup.js
@@ -10,7 +10,7 @@ module.exports = {
     name: 'testing-happiness.ga',
     path: '../../.',
     docker: {
-      image: 'zodern/meteor:latest'
+      image: 'zodern/meteor:root'
     },
     servers: {
       one: {}


### PR DESCRIPTION
I found in the doc to use this version `zodern/meteor:root` for the docker image.
See: https://meteor-up.com/docs.html#meteor-support
I figured it might worth a try to see if it can fix some of the deployment issues?

I don't know if master branch/testing server can actually do deployment though.. but we can't put it in deploy-phm because the app isn't working yet.. 